### PR TITLE
googletest cmake project cannot be cloned into the out-of-source dir,…

### DIFF
--- a/CanModuleTest/CMakeLists.txt
+++ b/CanModuleTest/CMakeLists.txt
@@ -4,8 +4,8 @@ find_package(Threads REQUIRED)
 
 function ( clone_googletest GOOGLETEST_VERSION)
   message(STATUS "cloning googletest from github. *NOTE* cloning [${GOOGLETEST_VERSION}]")
-  execute_process(COMMAND git clone -b ${GOOGLETEST_VERSION} https://github.com/google/googletest.git WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
-  message(STATUS "googletest cloned")    
+  execute_process(COMMAND git clone -b ${GOOGLETEST_VERSION} https://github.com/google/googletest.git WORKING_DIRECTORY ${PROJECT_SOURCE_DIR})
+  message(STATUS "googletest cloned to [${PROJECT_SOURCE_DIR}/googletest]")    
 endfunction()
 
 set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)


### PR DESCRIPTION
… it should be cloned to the source dir since it forms part of the source being built