### PR TITLE
Fix travis build v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ before_install:
 script:
  - docker run  --interactive --tty bfarnham/quasar:quasar-open62541 /bin/sh -c "
      echo '********************************************************************' ;
-     echo branch $TRAVIS_BRANCH ;
+     echo branch ${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} ;
      echo '********************************************************************' ;
-     git clone -b $TRAVIS_BRANCH https://github.com/quasar-team/CanModule.git ;
+     git clone -b ${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH} https://github.com/quasar-team/CanModule.git ;
      mkdir CanModule/build-release && cd CanModule/build-release ;
      apt-get install --quiet --assume-yes libsocketcan ;
      apt-get install --quiet --assume-yes libsocketcan-dev ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+sudo: required
+
+language: cpp
+
+services:
+ - docker
+
+before_install:
+ - docker pull bfarnham/quasar:quasar-open62541
+ 
+script:
+ - docker run  --interactive --tty bfarnham/quasar:quasar-open62541 /bin/sh -c "
+     echo '********************************************************************' ;
+     echo branch $TRAVIS_BRANCH ;
+     echo '********************************************************************' ;
+     git clone -b $TRAVIS_BRANCH https://github.com/quasar-team/CanModule.git ;
+     mkdir CanModule/build-release && cd CanModule/build-release ;
+     apt-get install --quiet --assume-yes libsocketcan ;
+     apt-get install --quiet --assume-yes libsocketcan-dev ;
+     export BOOST_PATH_HEADERS=/usr/include/ ;
+     export BOOST_PATH_LIBS=/usr/lib/x86_64-linux-gnu/ ;
+     cmake .. -DCMAKE_BUILD_TYPE=RELEASE -DSTANDALONE_BUILD=ON -DCMAKE_TOOLCHAIN_FILE=../boost_travis.cmake ;
+     make clean && make ;
+     exit ;
+     "

--- a/CanInterfaceImplementations/sockcan/CMakeLists.txt
+++ b/CanInterfaceImplementations/sockcan/CMakeLists.txt
@@ -19,7 +19,7 @@ else()
 	target_link_libraries( sockcan ${LOGIT_LIB} )
 endif()
 
-target_link_libraries ( sockcan ${BOOST_LIBS} libsocketcan.a )
+target_link_libraries ( sockcan ${BOOST_LIBS} libsocketcan.so )
 
 set_property(TARGET sockcan PROPERTY POSITION_INDEPENDENT_CODE TRUE)
 set_property(TARGET sockcan PROPERTY LINKER_LANGUAGE CXX)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-[![Build status](https://ci.appveyor.com/api/projects/status/7evxi9qnqc2iay1i/branch/master?svg=true)](https://ci.appveyor.com/project/ben-farnham/canmodule/branch/master)
+
+linux (by travis-ci.org) [![Build Status](https://travis-ci.org/quasar-team/CanModule.svg?branch=master)](https://travis-ci.org/quasar-team/CanModule)
+
+windows (by appveyor) [![Build status](https://ci.appveyor.com/api/projects/status/7evxi9qnqc2iay1i/branch/master?svg=true)](https://ci.appveyor.com/project/ben-farnham/canmodule/branch/master)
 
 # CanModule
 CanModule is a cross-platform library for controlling any kind of CAN device. All CAN devices are represented by a simple abstract interface (class CanModule::CCanAccess) - user code uses this interface (*only* this interface) to send messages, receive messages, etc. i.e. to interact with the CAN device as per the needs of the application. Of course, abstract interfaces require concrete implementations - these implementations are a kind of functional mapping; driving underlying CAN hardware through some lower level API in a way that satisifies the behaviour 'described' in the CCanAccess interface. CanModule comes out-of-the-box with implementations for certain CAN devices (see table below). Implementations for other CAN devices can be added - please submit a pull request with your implementation for review.

--- a/boost_travis.cmake
+++ b/boost_travis.cmake
@@ -1,0 +1,62 @@
+# LICENSE:
+# Copyright (c) 2018, Ben Farnham, CERN
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, 
+# THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS 
+# BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE 
+# GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT 
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Authors:
+# Ben Farnham <firstNm.secondNm@cern.ch>
+message(STATUS "Using file [boost_travis_cc7.cmake] toolchain file")
+message(STATUS "Boost - include environment variable BOOST_PATH_HEADERS [$ENV{BOOST_PATH_HEADERS}] libs environment variable BOOST_PATH_LIBS [$ENV{BOOST_PATH_LIBS}]")
+
+#-------
+# Boost headers
+#-------
+if( NOT DEFINED ENV{BOOST_PATH_HEADERS} OR NOT EXISTS $ENV{BOOST_PATH_HEADERS} )
+	message(FATAL_ERROR "environment variable BOOST_PATH_HEADERS must be set to a valid path for boost header files. Current value [$ENV{BOOST_PATH_HEADERS}] rejected")
+endif()
+message(STATUS "Boost - headers will be included from [$ENV{BOOST_PATH_HEADERS}]")
+include_directories( $ENV{BOOST_PATH_HEADERS} )
+ 
+
+#-------
+# Boost compiled libs
+#-------
+if( NOT DEFINED ENV{BOOST_PATH_LIBS} OR NOT EXISTS $ENV{BOOST_PATH_LIBS} )
+	message(FATAL_ERROR "environment variable BOOST_PATH_LIBS must be set to a valid path for boost compiled libraries. Current value [$ENV{BOOST_PATH_LIBS}] rejected")
+endif()
+message(STATUS "Boost - libraries will be linked from [$ENV{BOOST_PATH_LIBS}]")
+
+function( find_boost_static_library LIBRARY_IDENTIFIER LIBRARY_FILE_NAME)
+	SET(CMAKE_FIND_LIBRARY_SUFFIXES ".so")
+	SET(CMAKE_FIND_LIBRARY_PREFIXES "")
+
+	find_library(${LIBRARY_IDENTIFIER} NAMES ${LIBRARY_FILE_NAME} PATHS $ENV{BOOST_PATH_LIBS}  NO_DEFAULT_PATH)
+	message(STATUS "${LIBRARY_IDENTIFIER} has value [${${LIBRARY_IDENTIFIER}}]")
+	if(NOT ${LIBRARY_IDENTIFIER})
+		message(FATAL_ERROR "Failed to load boost static library ID [${LIBRARY_IDENTIFIER}] file [${LIBRARY_FILE_NAME}]")
+	endif()
+	message(STATUS "loaded boost static library [${LIBRARY_IDENTIFIER}] -> file [${${LIBRARY_IDENTIFIER}}]")
+endfunction()
+
+find_boost_static_library( libboostprogramoptions libboost_program_options )
+find_boost_static_library( libboostsystem libboost_system )
+find_boost_static_library( libboostfilesystem libboost_filesystem )
+find_boost_static_library( libboostchrono libboost_chrono )
+find_boost_static_library( libboostdatetime libboost_date_time) 
+find_boost_static_library( libboostthread libboost_thread)
+find_boost_static_library( libboostlog libboost_log)
+find_boost_static_library( libboostlogsetup libboost_log_setup)
+
+set( CMAKE_SKIP_RPATH TRUE )
+set( BOOST_LIBS ${libboostlogsetup} ${libboostlog} ${libboostsystem} ${libboostfilesystem} ${libboostthread} ${libboostprogramoptions} ${libboostchrono} ${libboostdatetime} -lrt)


### PR DESCRIPTION
Added a yml file for the travis build plus boost toolchain (links to system boost install).
Also changed the socketcan implementation shared library to link to the socketcan system *shared* library rather than the static library. Required since the socketcan impl library is built with fPIC, whereas the socketcan *static* library is not (so cannot link fPIC with non-fPIC).