### PR TITLE
quickfix to OPCUA-1355

### DIFF
--- a/CanInterface/include/CCanAccess.h
+++ b/CanInterface/include/CCanAccess.h
@@ -320,10 +320,10 @@ public:
 		string temporalString;
 		while (getline(nameSS, temporalString, ':')) {
 			stringVector.push_back(temporalString);
-			LOG(Log::TRC) << "CCanAccess::parcerNameAndPar: stringVector new element= " << temporalString;
+			LOG(Log::TRC) << __FUNCTION__ << " stringVector new element= " << temporalString;
 		}
 		m_CanParameters.scanParameters(parameters);
-		LOG(Log::TRC) << "CCanAccess::parcerNameAndPar: stringVector size= " << stringVector.size();
+		LOG(Log::TRC) << __FUNCTION__ << " stringVector size= " << stringVector.size();
 
 		return stringVector;
 	}

--- a/CanInterfaceImplementations/sockcan/SockCanScan.cpp
+++ b/CanInterfaceImplementations/sockcan/SockCanScan.cpp
@@ -198,7 +198,6 @@ void* CSockCanScan::CanScanControlThread(void *p_voidSockCanScan)
 							MLOG(ERR,p_sockCanScan) << "Waiting 10000ms failed (nanosleep)";
 						}
 					}
-//					usleep ( 10000000 ); // sleep(seconds);
 					if ( sock > 0 )	{
 						// try closing the socket
 						MLOG(INF,p_sockCanScan) << "Closing socket.";
@@ -307,7 +306,9 @@ int CSockCanScan::configureCanBoard(const string name,const string parameters)
 {
 	vector<string> parset;
 	parset = parseNameAndParameters( name, parameters );
-	m_channelName = parset[1];
+	std::ostringstream channelName;
+	channelName << "can" << parset[1]; // we need "can" prefixed for socketcan, but the user should not care
+	m_channelName = channelName.str();
 	return openCanPort();
 }
 


### PR DESCRIPTION
quickfix to OPCUA-1355
the prefix "can" is added to the socket name for socketcan, since the devices are called like that and we would like to have an uniform namin scheme for the user. I.e. "sock:1" and "st"1" and NOT "sock:can1" for that. Other vendors should follow the same style.
