### PR TITLE
Ml anagate reconnect fw

### DIFF
--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -395,7 +395,8 @@ bool AnaCanScan::sendMessage(short cobID, unsigned char len, unsigned char *mess
 					<< " found ip= " << ip
 					<< " for CAN port= " << it->second->canPortNumber()
 					<< " reconnecting...";
-			// todo: we should not add up the return calls of all ports, that is confusing
+
+			// cumulating the return codes is not such a good idea. please improve
 			ret += it->second->reconnect();
 			nbCANportsOnModule++;
 		}
@@ -485,19 +486,30 @@ int AnaCanScan::reconnect(){
 
 	int state = CANDeviceConnectState( m_UcanHandle );
 	MLOG(TRC, this) << "CANDeviceConnectState: device connect state= 0x" << hex << state << dec;
-	switch ( state ){
-	case 1: MLOG(TRC, this) << "1 = DISCONNECTED : The connection to the AnaGate is disconnected.";  break;
-	case 2: MLOG(TRC, this) << "2 = CONNECTING : The connection is connecting.";  break;
-	case 3: MLOG(TRC, this) << "3 = CONNECTED : The connection is established.";  break;
-	case 4: MLOG(TRC, this) << "4 = DISCONNECTING : The connection is disconnecting.";  break;
-	case 5: MLOG(TRC, this) << "5 = NOT_INITIALIZED : The network protocol is not successfully initialized.";  break;
-	}
+	/**
+	•
+	1 = DISCONNECTED
+	: The connection to the AnaGate is disconnected.
+	•
+	2 = CONNECTING
+	: The connection is connecting.
+	•
+	3 = CONNECTED
+	: The connection is established.
+	•
+	4 = DISCONNECTING
+	: The connection is disonnecting.
+	•
+	5 = NOT_INITIALIZED
+	: The network protocol is not successfully initialized.
+	*/
 
 	switch ( state ){
 	case 2: {
 		MLOG(INF,this) << "device is in state connecting, don't try to reconnect for now.";
 		break;
 	}
+
 	case 3: {
 		MLOG(INF,this) << "device is connecting, don't try to reconnect, just skip.";
 		break;
@@ -511,9 +523,9 @@ int AnaCanScan::reconnect(){
 			MLOG(WRN, this) << "closed device m_UcanHandle= " << m_UcanHandle
 					<< " anaCallReturn= 0x" << hex << anaCallReturn << dec;
 			if ( anaCallReturn != 0 ) {
-				MLOG(ERR, this) << "could not close device m_UcanHandle= " << m_UcanHandle
+				MLOG(WRN, this) << "could not close device m_UcanHandle= " << m_UcanHandle
 						<< " anaCallReturn= 0x" << hex << anaCallReturn << dec;
-				return(-3);
+				// return(-3);
 			}
 			m_canCloseDevice = true;
 			MLOG(TRC, this) << "device is closed. stale handle= " << m_UcanHandle;

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -395,6 +395,7 @@ bool AnaCanScan::sendMessage(short cobID, unsigned char len, unsigned char *mess
 					<< " found ip= " << ip
 					<< " for CAN port= " << it->second->canPortNumber()
 					<< " reconnecting...";
+			// todo: we should not add up the return calls of all ports, that is confusing
 			ret += it->second->reconnect();
 			nbCANportsOnModule++;
 		}

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -485,30 +485,19 @@ int AnaCanScan::reconnect(){
 
 	int state = CANDeviceConnectState( m_UcanHandle );
 	MLOG(TRC, this) << "CANDeviceConnectState: device connect state= 0x" << hex << state << dec;
-	/**
-	•
-	1 = DISCONNECTED
-	: The connection to the AnaGate is disconnected.
-	•
-	2 = CONNECTING
-	: The connection is connecting.
-	•
-	3 = CONNECTED
-	: The connection is established.
-	•
-	4 = DISCONNECTING
-	: The connection is disonnecting.
-	•
-	5 = NOT_INITIALIZED
-	: The network protocol is not successfully initialized.
-	*/
+	switch ( state ){
+	case 1: MLOG(TRC, this) << "1 = DISCONNECTED : The connection to the AnaGate is disconnected.";  break;
+	case 2: MLOG(TRC, this) << "2 = CONNECTING : The connection is connecting.";  break;
+	case 3: MLOG(TRC, this) << "3 = CONNECTED : The connection is established.";  break;
+	case 4: MLOG(TRC, this) << "4 = DISCONNECTING : The connection is disconnecting.";  break;
+	case 5: MLOG(TRC, this) << "5 = NOT_INITIALIZED : The network protocol is not successfully initialized.";  break;
+	}
 
 	switch ( state ){
 	case 2: {
 		MLOG(INF,this) << "device is in state connecting, don't try to reconnect for now.";
 		break;
 	}
-
 	case 3: {
 		MLOG(INF,this) << "device is connecting, don't try to reconnect, just skip.";
 		break;

--- a/CanInterfaceImplementations/sockcan/CMakeLists.txt
+++ b/CanInterfaceImplementations/sockcan/CMakeLists.txt
@@ -23,10 +23,12 @@ cmake_minimum_required(VERSION 2.8)
 project(sockcan)
 
 if( NOT DEFINED SOCKETCAN_PATH_LIBS )
-	message( STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: Required variable SOCKETCAN_PATH_LIBS has not been defined. assuming /usr/local/lib " )
 	SET ( SOCKETCAN_PATH_LIBS "/usr/local/lib" )
 	SET ( SOCKETCAN_HEADERS "/usr/local/include" )
 	SET ( SOCKETCAN_LIBS -lsocketcan )
+	message( STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: Required variable SOCKETCAN_PATH_LIBS has not been defined. assuming ${SOCKETCAN_PATH_LIBS} " )
+	message( STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: Required variable SOCKETCAN_HEADERS has not been defined. assuming ${SOCKETCAN_HEADERS} " )
+	message( STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: Required variable SOCKETCAN_LIBS has not been defined. assuming ${SOCKETCAN_LIBS} " )
 endif() 
 link_directories( ${SOCKETCAN_PATH_LIBS} )
 


### PR DESCRIPTION
a small fix to the anagate code to recuperate the connection also in case of a firmware reset. The return code is 0x90000 in that case because the fw is not replying during module restart, and we just have to wait 10 secs and reconnect from scratch.