### PR TITLE
protecting against 0 messages for sending

### DIFF
--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -229,8 +229,14 @@ int AnaCanScan::configureCanBoard(const string name,const string parameters)
 	m_baudRate = baudRate_default;
 
 	if (strcmp(parameters.c_str(), "Unspecified") != 0) {
+
+		MLOGANA(TRC, this) << "m_CanParameters.m_iNumberOfDetectedParameters" << m_CanParameters.m_iNumberOfDetectedParameters;
+
 		if ( m_CanParameters.m_iNumberOfDetectedParameters >= 1 )	{
 			m_baudRate = m_CanParameters.m_lBaudRate;
+
+			MLOGANA(TRC, this) << "m_baudRate= " << m_baudRate;
+
 			// any other parameters are already set, either to 0 by init,
 			// or by decoding. They are always used.
 		} else {
@@ -283,6 +289,15 @@ int AnaCanScan::openCanPort()
 	setCanHandleInUse(m_canPortNumber,true);
 
 	// initialize CAN interface
+
+	MLOGANA(TRC,this) << "calling CANSetGlobals with m_lBaudRate= "
+			<< m_CanParameters.m_lBaudRate
+			<< " m_iOperationMode= " << m_CanParameters.m_iOperationMode
+			<< " m_iTermination= " << m_CanParameters.m_iTermination
+			<< " m_iHighSpeed= " << m_CanParameters.m_iHighSpeed
+			<< " m_iTimeStamp= " << m_CanParameters.m_iTimeStamp;
+
+
 	anaCallReturn = CANSetGlobals(canModuleHandle, m_CanParameters.m_lBaudRate, m_CanParameters.m_iOperationMode,
 			m_CanParameters.m_iTermination, m_CanParameters.m_iHighSpeed, m_CanParameters.m_iTimeStamp);
 	switch ( anaCallReturn ){
@@ -353,7 +368,7 @@ bool AnaCanScan::sendErrorCode(AnaInt32 status)
  */
 bool AnaCanScan::sendMessage(short cobID, unsigned char len, unsigned char *message, bool rtr)
 {
-	MLOGANA(DBG,this) << "Sending message: [" << message << "], cobID: [" << cobID << "], Message Length: [" << static_cast<int>(len) << "]";
+	MLOGANA(DBG,this) << "Sending message: [" << ( message == 0  ? "" : (const char *) message) << "], cobID: [" << cobID << "], Message Length: [" << static_cast<int>(len) << "]";
 	AnaInt32 anaCallReturn;
 	unsigned char *messageToBeSent[8];
 	AnaInt32 flags = 0x0;

--- a/CanInterfaceImplementations/pkcan/pkcan.cpp
+++ b/CanInterfaceImplementations/pkcan/pkcan.cpp
@@ -297,6 +297,8 @@ bool PKCanScan::sendErrorCode(long status)
  */
 bool PKCanScan::sendMessage(short cobID, unsigned char len, unsigned char *message, bool rtr)
 {
+	MLOGPK(DBG,this) << "Sending message: [" << ( message == 0  ? "" : (const char *) message) << "], cobID: [" << cobID << "], Message Length: [" << static_cast<int>(len) << "]";
+
 	TPCANStatus tpcanStatus;
 	TPCANMsg tpcanMessage;
 	tpcanMessage.ID = cobID;

--- a/CanInterfaceImplementations/sockcan/SockCanScan.cpp
+++ b/CanInterfaceImplementations/sockcan/SockCanScan.cpp
@@ -402,6 +402,8 @@ int CSockCanScan::openCanPort()
  */
 bool CSockCanScan::sendMessage(short cobID, unsigned char len, unsigned char *message, bool rtr)
 {
+	MLOGSOCK(DBG,this) << "Sending message: [" << ( message == 0  ? "" : (const char *) message) << "], cobID: [" << cobID << "], Message Length: [" << static_cast<int>(len) << "]";
+
 	int messageLengthToBeProcessed;
 
 	struct can_frame canFrame = CSockCanScan::emptyCanFrame();

--- a/CanInterfaceImplementations/systec/STCanScan.cpp
+++ b/CanInterfaceImplementations/systec/STCanScan.cpp
@@ -298,6 +298,8 @@ bool STCanScan::sendErrorCode(long status)
  */
 bool STCanScan::sendMessage(short cobID, unsigned char len, unsigned char *message, bool rtr)
 {
+	MLOGST(DBG,this) << "Sending message: [" << ( message == 0  ? "" : (const char *) message) << "], cobID: [" << cobID << "], Message Length: [" << static_cast<int>(len) << "]";
+
 	tCanMsgStruct canMsgToBeSent;
 	BYTE Status;
 

--- a/CanInterfaceImplementations/unitTestMockUpImplementation/MockCanAccess.cpp
+++ b/CanInterfaceImplementations/unitTestMockUpImplementation/MockCanAccess.cpp
@@ -53,7 +53,7 @@ bool MockCanAccess::sendRemoteRequest(short cobID)
 
 bool MockCanAccess::sendMessage(short cobID, unsigned char len, unsigned char *message, bool rtr)
 {
-	LOG(Log::DBG) << __FUNCTION__ << " cobID ["<<cobID<<"] len ["<<(unsigned int)len<<"] message [0x"<<getCanMessageDataAsString(message, len)<<"] rtr ["<<rtr<<"]";
+	LOG(Log::DBG) << __FUNCTION__ << " Sending message: [" << ( message == 0  ? "" : (const char *) message) << "], cobID: [" << cobID << "], Message Length: [" << static_cast<int>(len) << "]";
 	m_statistics.onTransmit(len);
 
 	if(0 == memcmp(message, CAN_ECHO_MSG, len))


### PR DESCRIPTION
merge this fix for OPCUA-1415, for all vendors.
message printing with "unprintable" chars of course is as before, in TRC