### PR TITLE
hotfix opcua 1362

### DIFF
--- a/CanInterface/include/CCanAccess.h
+++ b/CanInterface/include/CCanAccess.h
@@ -350,6 +350,11 @@ public:
 	inline vector<string> parseNameAndParameters(string name, string parameters){
 		LOG(Log::TRC, _lh) << __FUNCTION__ << " name= " << name << " parameters= " << parameters;
 
+		// strip off any leading "can" from the port number,a according to OPCUA-1362
+		std::size_t found1 = name.find("can");
+		std::size_t found2 = name.find("CAN");
+		if (( found1 != std::string::npos ) || ( found2 != std::string::npos )) name = name.erase(0, 3);
+
 		m_sBusName = name;
 		vector<string> stringVector;
 		istringstream nameSS(name);

--- a/CanInterface/include/CCanAccess.h
+++ b/CanInterface/include/CCanAccess.h
@@ -30,7 +30,6 @@
 #else
 #include <sys/time.h>
 #endif
-#include <locale>         // std::locale, std::toupper
 #include "boost/bind.hpp"
 #include "boost/signals2.hpp"
 #include <string>
@@ -352,8 +351,6 @@ public:
 		LOG(Log::TRC, _lh) << __FUNCTION__ << " name= " << name << " parameters= " << parameters;
 
 		// strip off any leading "can" from the port number,a according to OPCUA-1362
-		string nu = std::toupper( name );
-
 		std::size_t found1 = name.find("can");
 		if ( found1 != std::string::npos ) name.erase( found1, 3);
 

--- a/CanInterface/include/CCanAccess.h
+++ b/CanInterface/include/CCanAccess.h
@@ -353,7 +353,7 @@ public:
 		// strip off any leading "can" from the port number,a according to OPCUA-1362
 		std::size_t found1 = name.find("can");
 		std::size_t found2 = name.find("CAN");
-		if (( found1 != std::string::npos ) || ( found2 != std::string::npos )) name = name.erase(0, 3);
+		if (( found1 != std::string::npos ) || ( found2 != std::string::npos )) name.erase(0, 3);
 
 		m_sBusName = name;
 		vector<string> stringVector;

--- a/CanInterface/include/CCanAccess.h
+++ b/CanInterface/include/CCanAccess.h
@@ -30,6 +30,7 @@
 #else
 #include <sys/time.h>
 #endif
+#include <locale>         // std::locale, std::toupper
 #include "boost/bind.hpp"
 #include "boost/signals2.hpp"
 #include <string>
@@ -351,9 +352,13 @@ public:
 		LOG(Log::TRC, _lh) << __FUNCTION__ << " name= " << name << " parameters= " << parameters;
 
 		// strip off any leading "can" from the port number,a according to OPCUA-1362
+		string nu = std::toupper( name );
+
 		std::size_t found1 = name.find("can");
+		if ( found1 != std::string::npos ) name.erase( found1, 3);
+
 		std::size_t found2 = name.find("CAN");
-		if (( found1 != std::string::npos ) || ( found2 != std::string::npos )) name.erase(0, 3);
+		if ( found2 != std::string::npos ) name.erase( found2, 3);
 
 		m_sBusName = name;
 		vector<string> stringVector;


### PR DESCRIPTION
hotfix!
fixed a bug related to OPCUA-1362 ("can1" and "1" equally allowed to specify port 1), which slipped in. 
* The atoi returned 0 if it has to convert i.e. "can1", that's fixed.
* apologies, this slipped through testing
* retag for 1.1.3
