### PR TITLE
Fix anagate receiver reconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - in 1.1.4, the anagate actually did not fully recover from a disconnect, the reception handler 
   was missing. Inserted a CANSetGlobals call to get the mod up again. The duo comes up
   relatively fast (20secs), and the X4/X8 take a bit longer to recuperate (60secs), but all
-  reception handlers are fine after a power loss FOR CC7. For windows: not working...
+  reception handlers are fine after a power loss FOR CC7. For windows, the reply
+  handlers are NOT reconnected, and the obj. map stays as before. The windows API 
+  behaves differently, but that is also working now.
   
   
 ### 1.1.3, 1.1.4 are intermediate, some bugs, don't use  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
   reception handlers are fine after a power loss FOR CC7. For windows, the reply
   handlers are NOT reconnected, and the obj. map stays as before. The windows API 
   behaves differently, but that is also working now.
-  
+  reconnection tests: anagate duo , X4/X8, on w2016s, w10e, cc7, w2008r2 - all ok
+     
   
 ### 1.1.3, 1.1.4 are intermediate, some bugs, don't use  
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - create a decent pdf from the sphinx doc, via latex tools.
 - protection against several createBus calls for systec/linux
 
+## [1.1.5] 18.june.2019
+### Fixed
+- in 1.1.4, the anagate actually did not fully recover from a disconnect, the reception handler 
+  was missing. Inserted a CANSetGlobals call to get the mod up again. The duo comes up
+  relatively fast (20secs), and the X4/X8 take a bit longer to recuperate (60secs), but all
+  reception handlers are fine after a power loss.
+  
+  
+### 1.1.3, 1.1.4 are intermediate, some bugs, don't use  
+
 ## [1.1.2] 23.may.2019
 ### Added
 - PEAK works for USB / USB Pro briges for linux and windows, but NOT for PEAK-USB FD

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - in 1.1.4, the anagate actually did not fully recover from a disconnect, the reception handler 
   was missing. Inserted a CANSetGlobals call to get the mod up again. The duo comes up
   relatively fast (20secs), and the X4/X8 take a bit longer to recuperate (60secs), but all
-  reception handlers are fine after a power loss.
+  reception handlers are fine after a power loss FOR CC7. For windows: not working...
   
   
 ### 1.1.3, 1.1.4 are intermediate, some bugs, don't use  

--- a/CanInterface/include/CCanAccess.h
+++ b/CanInterface/include/CCanAccess.h
@@ -38,7 +38,7 @@
 #include <LogIt.h>
 
 
-#define VERSION "CanModule version 1.1.1"
+#define VERSION "CanModule version 1.1.5"
 
 /*
  * CCanAccess is an abstract class that defines the interface for controlling a canbus. Different implementations for different hardware and platforms should

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -557,9 +557,9 @@ bool AnaCanScan::sendMessage(short cobID, unsigned char len, unsigned char *mess
 	for (std::map<AnaInt32, AnaCanScan*>::iterator it=lmap.begin(); it!=lmap.end(); it++){
 		if ( ip == it->second->ipAdress() ){
 
-#if _WIN32
+//#if _WIN32
 			// don't reconnect handler for windows
-#else
+//#else
 			anaRet = it->second->connectReceptionHandler();
 			if ( anaRet != 0 ){
 				LOG(Log::ERR, AnaCanScan::s_logItHandleAnagate) << __FUNCTION__ << " " __FILE__ << " " << __LINE__
@@ -574,7 +574,7 @@ bool AnaCanScan::sendMessage(short cobID, unsigned char len, unsigned char *mess
 			LOG(Log::TRC, AnaCanScan::s_logItHandleAnagate) << __FUNCTION__ << " " __FILE__ << " " << __LINE__
 					<< " erasing stale handler " << it->first << " from obj. map";
 			g_AnaCanScanPointerMap.erase( it->first );
-#endif
+//#endif
 
 			AnaCanScan::setIpReconnectInProgress( ip, false ); // all done, may fail another time
 			LOG(Log::TRC, AnaCanScan::s_logItHandleAnagate ) << "reconnecting all ports for ip= " << ip

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -576,9 +576,18 @@ bool AnaCanScan::sendMessage(short cobID, unsigned char len, unsigned char *mess
 
 //#endif
 #if _WIN32
+			/**
+			 * delete the map elements where the key is different from the handle, since we reassigned handles
+			 * in the living objects like:
+			 * 	g_AnaCanScanPointerMap[ m_UcanHandle ] = this;
+			 */
+			if ( it->first != it->second->handle()){
+				g_AnaCanScanPointerMap.erase( it->first );
+			}
 #else
 			LOG(Log::TRC, AnaCanScan::s_logItHandleAnagate) << __FUNCTION__ << " " __FILE__ << " " << __LINE__
-					<< " erasing stale handler " << it->first << " from obj. map";
+					<< " erasing stale handler " << it->first
+					<< " for object handle= " << it->second->handle() << " from obj. map";
 			g_AnaCanScanPointerMap.erase( it->first );
 #endif
 

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -556,7 +556,7 @@ bool AnaCanScan::sendMessage(short cobID, unsigned char len, unsigned char *mess
 						<< " anaRet= " << anaRet;
 			} else {
 				LOG(Log::TRC, AnaCanScan::s_logItHandleAnagate ) << __FUNCTION__ << " " __FILE__ << " " << __LINE__
-						<< " debug reconnect reception handler for ip= " << ip
+						<< " reconnect reception handler for ip= " << ip
 						<< " handle= " << it->second->handle()
 						<< " looking good= " << anaRet;
 			}
@@ -582,10 +582,8 @@ bool AnaCanScan::sendMessage(short cobID, unsigned char len, unsigned char *mess
  */
 AnaInt32 AnaCanScan::connectReceptionHandler(){
 	AnaInt32 anaCallReturn;
-	MLOGANA(WRN,this) << "debug CANSetGlobals= " << m_UcanHandle
-			<< " ip= " << m_canIPAddress
-			<< " this= 0x" << hex << (this) << dec;
 
+	// this is needed otherwise the bridge hangs in a bad state
 	anaCallReturn = CANSetGlobals(m_UcanHandle, m_CanParameters.m_lBaudRate, m_CanParameters.m_iOperationMode,
 			m_CanParameters.m_iTermination, m_CanParameters.m_iHighSpeed, m_CanParameters.m_iTimeStamp);
 	switch ( anaCallReturn ){
@@ -612,9 +610,9 @@ AnaInt32 AnaCanScan::connectReceptionHandler(){
 			<< " ip= " << m_canIPAddress;
 	anaCallReturn = CANSetCallbackEx(m_UcanHandle, InternalCallback);
 	if (anaCallReturn != 0) {
-		MLOGANA(ERR,this) << "Error debug in CANSetCallbackEx, return code = [" << anaCallReturn << "]"
+		MLOGANA(ERR,this) << "failed CANSetCallbackEx, return code = [" << anaCallReturn << "]"
 				<< " canModuleHandle= " << m_UcanHandle
-				<< " in a reconnect! Can't fix this. Restart program and buy better hardware please.";
+				<< " in a reconnect! Can't fix this, maybe hardware/firmware problem.";
 		// that is very schlecht, need a good idea (~check keepalive and sending fake messages)
 		// to detect and possibly recuperate from that. Does this case happen actually?
 	}

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -547,6 +547,11 @@ bool AnaCanScan::sendMessage(short cobID, unsigned char len, unsigned char *mess
 	std::map<AnaInt32, AnaCanScan*> lmap = g_AnaCanScanPointerMap; // use a local copy of the map, in order
 	// not to change the map we are iterating on
 
+	//before
+	LOG(Log::TRC, AnaCanScan::s_logItHandleAnagate) << __FUNCTION__ << " " __FILE__ << " " << __LINE__
+							<< " debug map before for ip= " << ip;
+	AnaCanScan::objectMapSize();
+
 	for (std::map<AnaInt32, AnaCanScan*>::iterator it=lmap.begin(); it!=lmap.end(); it++){
 		if ( ip == it->second->ipAdress() ){
 			anaRet = it->second->connectReceptionHandler();
@@ -570,6 +575,11 @@ bool AnaCanScan::sendMessage(short cobID, unsigned char len, unsigned char *mess
 					<< " is done and OK.";
 		}
 	}
+	//after
+	LOG(Log::TRC, AnaCanScan::s_logItHandleAnagate) << __FUNCTION__ << " " __FILE__ << " " << __LINE__
+							<< " debug map after for ip= " << ip;
+	AnaCanScan::objectMapSize();
+
 	int us = 1000000;
 	boost::this_thread::sleep(boost::posix_time::microseconds( us ));
 	return( anaRet );

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -557,7 +557,7 @@ bool AnaCanScan::sendMessage(short cobID, unsigned char len, unsigned char *mess
 	for (std::map<AnaInt32, AnaCanScan*>::iterator it=lmap.begin(); it!=lmap.end(); it++){
 		if ( ip == it->second->ipAdress() ){
 
-#if WIN32
+#if _WIN32
 			// don't reconnect handler for windows
 #else
 			anaRet = it->second->connectReceptionHandler();

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -457,7 +457,7 @@ bool AnaCanScan::sendMessage(short cobID, unsigned char len, unsigned char *mess
 				<< " CAN port= " << it->second->canPortNumber()
 				<< " handle= " << it->second->handle()
 				<< " (used?= " << it->second->isCanHandleInUse(it->second->handle()) << ")"
-				<< " ptr= 0x" << hex << (unsigned long) this << dec;
+				<< " ptr= 0x" << hex << (unsigned long) (it->second) << dec;
 
 	}
 }

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -564,6 +564,8 @@ bool AnaCanScan::sendMessage(short cobID, unsigned char len, unsigned char *mess
 			if ( anaRet != 0 ){
 				LOG(Log::ERR, AnaCanScan::s_logItHandleAnagate) << __FUNCTION__ << " " __FILE__ << " " << __LINE__
 						<< " failed to reconnect reception handler for ip= " << ip
+						<< " handle= " << it->second->handle()
+						<< " port= " << it->second->canPortNumber()
 						<< " anaRet= " << anaRet;
 			} else {
 				LOG(Log::TRC, AnaCanScan::s_logItHandleAnagate ) << __FUNCTION__ << " " __FILE__ << " " << __LINE__

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -549,17 +549,12 @@ bool AnaCanScan::sendMessage(short cobID, unsigned char len, unsigned char *mess
 	std::map<AnaInt32, AnaCanScan*> lmap = g_AnaCanScanPointerMap; // use a local copy of the map, in order
 	// not to change the map we are iterating on
 
-	//before
 	LOG(Log::TRC, AnaCanScan::s_logItHandleAnagate) << __FUNCTION__ << " " __FILE__ << " " << __LINE__
-			<< " debug map before for ip= " << ip;
+			<< " receive handler map map before reconnect for ip= " << ip;
 	AnaCanScan::objectMapSize();
 
 	for (std::map<AnaInt32, AnaCanScan*>::iterator it=lmap.begin(); it!=lmap.end(); it++){
 		if ( ip == it->second->ipAdress() ){
-
-//#if _WIN32
-			// don't reconnect handler for windows
-//#else
 			anaRet = it->second->connectReceptionHandler();
 			if ( anaRet != 0 ){
 				LOG(Log::ERR, AnaCanScan::s_logItHandleAnagate) << __FUNCTION__ << " " __FILE__ << " " << __LINE__
@@ -574,8 +569,6 @@ bool AnaCanScan::sendMessage(short cobID, unsigned char len, unsigned char *mess
 						<< " looking good= " << anaRet;
 			}
 
-//#endif
-//#if _WIN32
 			/**
 			 * delete the map elements where the key is different from the handle, since we reassigned handles
 			 * in the living objects like:
@@ -587,23 +580,16 @@ bool AnaCanScan::sendMessage(short cobID, unsigned char len, unsigned char *mess
 						<< " for object handle= " << it->second->handle() << " from obj. map";
 				g_AnaCanScanPointerMap.erase( it->first );
 			}
-//#else
-//			LOG(Log::TRC, AnaCanScan::s_logItHandleAnagate) << __FUNCTION__ << " " __FILE__ << " " << __LINE__
-//					<< " erasing stale handler " << it->first
-//					<< " for object handle= " << it->second->handle() << " from obj. map";
-//			g_AnaCanScanPointerMap.erase( it->first );
-//#endif
-
 			AnaCanScan::setIpReconnectInProgress( ip, false ); // all done, may fail another time
 			LOG(Log::TRC, AnaCanScan::s_logItHandleAnagate ) << "reconnecting all ports for ip= " << ip
 					<< " is done and OK.";
 		}
 	}
-	//after
 	LOG(Log::TRC, AnaCanScan::s_logItHandleAnagate) << __FUNCTION__ << " " __FILE__ << " " << __LINE__
-			<< " debug map after for ip= " << ip;
+			<< " receive handler map after reconnect for ip= " << ip;
 	AnaCanScan::objectMapSize();
 
+	// be easy on the switch, can maybe suppress this later
 	int us = 100000;
 	boost::this_thread::sleep(boost::posix_time::microseconds( us ));
 	return( anaRet );

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -558,6 +558,10 @@ bool AnaCanScan::sendMessage(short cobID, unsigned char len, unsigned char *mess
 
 	for (std::map<AnaInt32, AnaCanScan*>::iterator it=lmap.begin(); it!=lmap.end(); it++){
 		if ( ip == it->second->ipAdress() ){
+
+#if WIN32
+			// don't reconnect handler for windows
+#else
 			anaRet = it->second->connectReceptionHandler();
 			if ( anaRet != 0 ){
 				LOG(Log::ERR, AnaCanScan::s_logItHandleAnagate) << __FUNCTION__ << " " __FILE__ << " " << __LINE__
@@ -569,10 +573,6 @@ bool AnaCanScan::sendMessage(short cobID, unsigned char len, unsigned char *mess
 						<< " handle= " << it->second->handle()
 						<< " looking good= " << anaRet;
 			}
-
-#if WIN32
-			// handlers don't change for windows, keep them in the map
-#else
 			LOG(Log::TRC, AnaCanScan::s_logItHandleAnagate) << __FUNCTION__ << " " __FILE__ << " " << __LINE__
 					<< " erasing stale handler " << it->first << " from obj. map";
 			g_AnaCanScanPointerMap.erase( it->first );

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -365,6 +365,9 @@ int AnaCanScan::openCanPort()
 	// We associate in the global map the handle with the instance of the AnaCanScan object,
 	// so it can later be identified by the callback InternalCallback in a speedy way
 	m_UcanHandle = canModuleHandle;
+
+	MLOGANA(TRC,this) << "handles: ";
+	AnaCanScan::objectMapSize();
 	return 0;
 }
 

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -575,21 +575,24 @@ bool AnaCanScan::sendMessage(short cobID, unsigned char len, unsigned char *mess
 			}
 
 //#endif
-#if _WIN32
+//#if _WIN32
 			/**
 			 * delete the map elements where the key is different from the handle, since we reassigned handles
 			 * in the living objects like:
 			 * 	g_AnaCanScanPointerMap[ m_UcanHandle ] = this;
 			 */
 			if ( it->first != it->second->handle()){
+				LOG(Log::TRC, AnaCanScan::s_logItHandleAnagate) << __FUNCTION__ << " " __FILE__ << " " << __LINE__
+						<< " erasing stale handler " << it->first
+						<< " for object handle= " << it->second->handle() << " from obj. map";
 				g_AnaCanScanPointerMap.erase( it->first );
 			}
-#else
-			LOG(Log::TRC, AnaCanScan::s_logItHandleAnagate) << __FUNCTION__ << " " __FILE__ << " " << __LINE__
-					<< " erasing stale handler " << it->first
-					<< " for object handle= " << it->second->handle() << " from obj. map";
-			g_AnaCanScanPointerMap.erase( it->first );
-#endif
+//#else
+//			LOG(Log::TRC, AnaCanScan::s_logItHandleAnagate) << __FUNCTION__ << " " __FILE__ << " " << __LINE__
+//					<< " erasing stale handler " << it->first
+//					<< " for object handle= " << it->second->handle() << " from obj. map";
+//			g_AnaCanScanPointerMap.erase( it->first );
+//#endif
 
 			AnaCanScan::setIpReconnectInProgress( ip, false ); // all done, may fail another time
 			LOG(Log::TRC, AnaCanScan::s_logItHandleAnagate ) << "reconnecting all ports for ip= " << ip

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -570,9 +570,13 @@ bool AnaCanScan::sendMessage(short cobID, unsigned char len, unsigned char *mess
 						<< " looking good= " << anaRet;
 			}
 
+#if WIN32
+			// handlers don't change for windows, keep them in the map
+#else
 			LOG(Log::TRC, AnaCanScan::s_logItHandleAnagate) << __FUNCTION__ << " " __FILE__ << " " << __LINE__
 					<< " erasing stale handler " << it->first << " from obj. map";
 			g_AnaCanScanPointerMap.erase( it->first );
+#endif
 
 			AnaCanScan::setIpReconnectInProgress( ip, false ); // all done, may fail another time
 			LOG(Log::TRC, AnaCanScan::s_logItHandleAnagate ) << "reconnecting all ports for ip= " << ip

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -582,6 +582,32 @@ bool AnaCanScan::sendMessage(short cobID, unsigned char len, unsigned char *mess
  */
 AnaInt32 AnaCanScan::connectReceptionHandler(){
 	AnaInt32 anaCallReturn;
+	MLOGANA(WRN,this) << "debug CANSetGlobals= " << m_UcanHandle
+			<< " ip= " << m_canIPAddress
+			<< " this= 0x" << hex << (this) << dec;
+
+	anaCallReturn = CANSetGlobals(m_UcanHandle, m_CanParameters.m_lBaudRate, m_CanParameters.m_iOperationMode,
+			m_CanParameters.m_iTermination, m_CanParameters.m_iHighSpeed, m_CanParameters.m_iTimeStamp);
+	switch ( anaCallReturn ){
+	case 0:{ break; }
+	case 0x30000: {
+		MLOGANA(ERR,this) << "Connection to TCP/IP partner can't be established or is disconnected. Lost TCP/IP: 0x" << hex << anaCallReturn << dec;
+		return -1;
+	}
+	case 0x40000: {
+		MLOGANA(ERR,this) << "No  answer  was  received  from	TCP/IP partner within the defined timeout. Lost TCP/IP: 0x" << hex << anaCallReturn << dec;
+		return -1;
+	}
+	case 0x900000: {
+		MLOGANA(ERR,this) << "Invalid device handle. Lost TCP/IP: 0x" << hex << anaCallReturn << dec;
+		return -1;
+	}
+	default : {
+		MLOGANA(ERR,this) << "Other Error in CANSetGlobals: 0x" << hex << anaCallReturn << dec;
+		return -1;
+	}
+	}
+
 	MLOGANA(WRN,this) << "connecting RECEIVE canModuleHandle= " << m_UcanHandle
 			<< " ip= " << m_canIPAddress;
 	anaCallReturn = CANSetCallbackEx(m_UcanHandle, InternalCallback);

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -573,10 +573,14 @@ bool AnaCanScan::sendMessage(short cobID, unsigned char len, unsigned char *mess
 						<< " handle= " << it->second->handle()
 						<< " looking good= " << anaRet;
 			}
+
+//#endif
+#if _WIN32
+#else
 			LOG(Log::TRC, AnaCanScan::s_logItHandleAnagate) << __FUNCTION__ << " " __FILE__ << " " << __LINE__
 					<< " erasing stale handler " << it->first << " from obj. map";
 			g_AnaCanScanPointerMap.erase( it->first );
-//#endif
+#endif
 
 			AnaCanScan::setIpReconnectInProgress( ip, false ); // all done, may fail another time
 			LOG(Log::TRC, AnaCanScan::s_logItHandleAnagate ) << "reconnecting all ports for ip= " << ip

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -456,7 +456,8 @@ bool AnaCanScan::sendMessage(short cobID, unsigned char len, unsigned char *mess
 				<< " ip= " << it->second->ipAdress()
 				<< " CAN port= " << it->second->canPortNumber()
 				<< " handle= " << it->second->handle()
-				<< " (used?= " << it->second->isCanHandleInUse(it->second->handle()) << ")";
+				<< " (used?= " << it->second->isCanHandleInUse(it->second->handle()) << ")"
+				<< " ptr= 0x" << hex << (unsigned long) this << dec;
 
 	}
 }

--- a/Documentation/sphinx-source/connection.rst
+++ b/Documentation/sphinx-source/connection.rst
@@ -29,7 +29,9 @@ takes at least ~20sec, so it takes ~1 minute to reestablish communication. All r
 are lost, and not all sent frames are guaranteed, therefore some care has to be taken when the
 connection is reestablished concerning the statuses of CAN slaves. CanModule reports reconnections
 as warnings, but there is no systematic CanModule-API yet to handle reconnections 
-systematically (is it needed?).      
+systematically (is it needed?). 
+	The anagate duo reconnects somewhat faster than the X4/X8 modules, because of firmware differences.
+The whole reconnection can take up to 60 secs until all buffers are cleared, so please be patient.     
 
 peak and systec
 ---------------


### PR DESCRIPTION
anagate reconnection behaviour corrected, again, and this time also tested on
cc7, w10e, w2016s, w2008r2 with anagate/duo and anagate X4/X8 multiple modules and ports.
- all reception handlers reconnect OK now
- stale handles/objetcs are removed from the handler map 
- multiple reconnections do not produce mem grow or any other adverse effects as far as I can see