### PR TITLE
Opcua 1356 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - create a decent pdf from the sphinx doc, via latex tools.
 - protection against several createBus calls for systec/linux
 
+### in progress
+- 64BIT/32BIT switch, assume defaults 64BIT but allow toolchain override with 32BIT explicitly
+  for all vendors/windows
+
 ## [1.1.5] 18.june.2019
 ### Fixed
 - in 1.1.4, the anagate actually did not fully recover from a disconnect, the reception handler 

--- a/CanInterfaceImplementations/anagate/CMakeLists.txt
+++ b/CanInterfaceImplementations/anagate/CMakeLists.txt
@@ -29,31 +29,35 @@ SET( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/CanInterfaceImplementati
 # convenience libs to wrap the tcp specific telegrams needed for anagate into a nice API. 
 # and this needs no driver install etc. Spec for anagate libs 
 # is at http://www.anagate.de/download/Manual-AnaGate-TCPIP-V1.2.6-EN.pdf 
-if( NOT DEFINED ANAGATE_PATH_LIBS ) 
-	message( STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: Required variable ANAGATE_LIB_FILE has not been defined, take default." )
-	message( STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: Required variable ANAGATE_INC_DIR has not been defined, take default." )
-	message( STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: Required variable ANAGATE_PATH_LIBS has not been defined, take default." )
+if( (NOT DEFINED ANAGATE_LIB_PATH) OR (NOT DEFINED ANAGATE_HEADERS) OR (NOT DEFINED ANAGATE_LIB_FILE)  )
+	message(WARNING "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: Required variable ANAGATE_LIB_PATH has not been defined." )
+	message(WARNING "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: Required variable ANAGATE_HEADERS has not been defined." )
+	message(WARNING "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: Required variable ANAGATE_LIB_FILE has not been defined." )
+	message(WARNING "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: assuming default locations and libs for anagate (linux, windows)" )
+	message(WARNING "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: since anagate does not have an installer the default locations are likely to be wrong" )
 	if(WIN32)  
-		if( 64BIT )  
-			SET( ANAGATE_INC_DIR "C:/3rdPartySoftware/AnaGateCAN/win64/vc8/include")
-			SET( ANAGATE_PATH_LIBS "C:/3rdPartySoftware/AnaGateCAN/win64/vc8/Release")
-			SET( ANAGATE_LIB_FILE "C:/3rdPartySoftware/AnaGateCAN/win64/vc8/Release/AnaGateCanDll64.lib")
-		else()
-			SET( ANAGATE_INC_DIR "/3rdPartySoftware/AnaGateCAN/win32/vc8/include")
-			SET( ANAGATE_PATH_LIBS "/3rdPartySoftware/AnaGateCAN/win32/vc8/Release")
-			SET( ANAGATE_LIB_FILE "/3rdPartySoftware/AnaGateCAN/win32/vc8/Release/AnaGateCanDll.lib")
-		endif()
+		SET( ANAGATE_HEADERS "C:/3rdPartySoftware/AnaGateCAN/win64/vc8/include")
+		SET( ANAGATE_LIB_PATH "C:/3rdPartySoftware/AnaGateCAN/win64/vc8/Release")
+		SET( ANAGATE_LIB_FILE "C:/3rdPartySoftware/AnaGateCAN/win64/vc8/Release/AnaGateCanDll64.lib")
+
+		# for 32BIT, use toolchain override
+		#SET( ANAGATE_HEADERS "/3rdPartySoftware/AnaGateCAN/win32/vc8/include")
+		#SET( ANAGATE_LIB_PATH "/3rdPartySoftware/AnaGateCAN/win32/vc8/Release")
+		#SET( ANAGATE_LIB_FILE "/3rdPartySoftware/AnaGateCAN/win32/vc8/Release/AnaGateCanDll.lib")
 	else()
-		SET ( ANAGATE_PATH_LIBS "/opt/3rdPartySoftware/Anagate/CAN/anagate-api-2.13/linux64/gcc4_6" )
-		SET ( ANAGATE_INC_DIR "/opt/3rdPartySoftware/Anagate/CAN/anagate-api-2.13/linux64/gcc4_6/include" )
+		SET ( ANAGATE_HEADERS "/opt/3rdPartySoftware/Anagate/CAN/anagate-api-2.13/linux64/gcc4_6/include" )
+		SET ( ANAGATE_LIB_PATH "/opt/3rdPartySoftware/Anagate/CAN/anagate-api-2.13/linux64/gcc4_6" )
 		SET ( ANAGATE_LIB_FILE "-lAPIRelease64 -lCANDLLRelease64" )
 	endif() 
-ENDIF()
+	message(STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: ANAGATE_HEADERS=  ${ANAGATE_HEADERS}]")
+	message(STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: ANAGATE_LIB_PATH= ${ANAGATE_LIB_PATH}]")
+	message(STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: ANAGATE_LIB_FILE= ${ANAGATE_LIB_FILE}]")
+else()
+  	message(STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: toolchain ANAGATE_LIB_PATH= ${ANAGATE_LIB_PATH}" )
+  	message(STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: toolchain ANAGATE_HEADERS=  ${ANAGATE_HEADERS}" )
+  	message(STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: toolchain ANAGATE_LIB_FILE= ${ANAGATE_LIB_FILE}" )
+endif() 
 
-message(STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: ANAGATE_INC_DIR= ${ANAGATE_INC_DIR}]")
-message(STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: ANAGATE_PATH_LIBS= ${ANAGATE_PATH_LIBS}]")
-message(STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: ANAGATE_LIB_FILE= ${ANAGATE_LIB_FILE}]")
- 
 
 set(ANAGATE_SOURCES
 	AnaCanScan.cpp
@@ -74,7 +78,6 @@ else()
 	target_link_libraries( ancan ${LOGIT_LIB} )
 endif()
 
-#checkCANImplResourceExists(ANAGATE_LIB_FILE ${ANAGATE_LIB_HINT})
 target_link_libraries ( ancan ${BOOST_LIBS}	${ANAGATE_LIB_FILE} )
 
 set_property(TARGET ancan PROPERTY POSITION_INDEPENDENT_CODE TRUE)

--- a/CanInterfaceImplementations/pkcan/CMakeLists.txt
+++ b/CanInterfaceImplementations/pkcan/CMakeLists.txt
@@ -1,4 +1,4 @@
-# © Copyright CERN, Geneva, Switzerland, 2016.  All rights not expressly granted are reserved.
+# ï¿½ Copyright CERN, Geneva, Switzerland, 2016.  All rights not expressly granted are reserved.
 #
 #   Created on: Wed Aug 30 10:15:57 CEST 2017
 # 
@@ -25,23 +25,33 @@ project(pkcan)
 SET( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/CanInterfaceImplementations/output/)
 
 # check if toolchain injection was correct for peak
-if( NOT DEFINED PEAK_PATH_LIBS ) 
-	message( STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: Required variable PEAK_LIB_FILE has not been defined, take default." )
-	message( STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: Required variable PEAK_INC_DIR has not been defined, take default." )
-	message( STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: Required variable PEAK_PATH_LIBS has not been defined, take default." )
-	if(WIN32)  
-			SET( PEAK_INC_DIR "C:/3rdPartySoftware/PeakCAN/pcan-basic/PCAN-Basic API/Include")
-			SET( PEAK_PATH_LIBS "C:/3rdPartySoftware/PeakCAN/pcan-basic/PCAN-Basic API/x64/VC_LIB")
-			SET( PEAK_LIB_FILE "PCANBasic.lib")
-	else()
-		message(ERROR "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: this directory is only needed for PEAK/windows, it must be skipped for Linux]")
-	endif() 
-ENDIF()
+# for windows we should use the default peak installer and location
+# for linux we need libsocketcan
+if( (NOT DEFINED PEAK_LIB_PATH) OR (NOT DEFINED PEAK_HEADERS) OR (NOT DEFINED PEAK_LIB_FILE)  )
+	message(WARNING "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: Required variable PEAK_HEADERS has not been defined." )
+	message(WARNING "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: Required variable PEAK_LIB_PATH has not been defined." )
+	message(WARNING "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: Required variable PEAK_LIB_FILE has not been defined." )
+	message(WARNING "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: assuming default locations and libs for peak and windows" )
+	if(WIN32)
+		SET(PEAK_HEADERS "C:/3rdPartySoftware/PeakCAN/pcan-basic/PCAN-Basic API/Include")
+		SET(PEAK_LIB_PATH "C:/3rdPartySoftware/PeakCAN/pcan-basic/PCAN-Basic API/x64/VC_LIB")
+		SET(PEAK_LIB_FILE "PCANBasic.lib")
+		# for 32 bit 
+		# SET(PEAK_LIB_PATH "C:/3rdPartySoftware/PeakCAN/pcan-basic/PCAN-Basic API/x32/VC_LIB")
 
-message(STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: PEAK_INC_DIR= ${PEAK_INC_DIR}]")
-message(STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: PEAK_PATH_LIBS= ${PEAK_PATH_LIBS}]")
-message(STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: PEAK_LIB_FILE= ${PEAK_LIB_FILE}]")
- 
+		message(STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: windows PEAK_LIB_PATH= ${PEAK_LIB_PATH}]")
+ 		message(STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: windows PEAK_HEADERS=  ${PEAK_HEADERS}]")
+ 		message(STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: windows PEAK_LIB_FILE= ${PEAK_LIB_FILE}]")
+	else()
+	    # since we use socketcan for linux for systec, we are in the wrong directory
+		message( FATAL_ERROR "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: linux uses socketcan (directory sockcan) for peak, you are building the wrong directory." )
+	endif()
+else()
+  message(STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: toolchain PEAK_LIB_PATH= ${PEAK_LIB_PATH}" )
+  message(STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: toolchain PEAK_HEADERS=  ${PEAK_HEADERS}" )
+  message(STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: toolchain PEAK_LIB_FILE= ${PEAK_LIB_FILE}" )
+endif() 
+
 set(PEAKCAN_SOURCES
 	pkcan.cpp
 	pkcan.h

--- a/CanInterfaceImplementations/sockcan/CMakeLists.txt
+++ b/CanInterfaceImplementations/sockcan/CMakeLists.txt
@@ -22,15 +22,15 @@
 cmake_minimum_required(VERSION 2.8)
 project(sockcan)
 
-if( NOT DEFINED SOCKETCAN_PATH_LIBS )
-	SET ( SOCKETCAN_PATH_LIBS "/usr/local/lib" )
+if( (NOT DEFINED SOCKETCAN_LIB_PATH) OR (NOT DEFINED SOCKETCAN_HEADERS) OR (NOT DEFINED SOCKETCAN_LIB_FILE)  )
+	SET ( SOCKETCAN_LIB_PATH "/usr/local/lib" )
 	SET ( SOCKETCAN_HEADERS "/usr/local/include" )
-	SET ( SOCKETCAN_LIBS -lsocketcan )
-	message( STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: Required variable SOCKETCAN_PATH_LIBS has not been defined. assuming ${SOCKETCAN_PATH_LIBS} " )
+	SET ( SOCKETCAN_LIB_FILE -lsocketcan )
+	message( STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: Required variable SOCKETCAN_LIB_PATH has not been defined. assuming ${SOCKETCAN_PATH_LIBS} " )
 	message( STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: Required variable SOCKETCAN_HEADERS has not been defined. assuming ${SOCKETCAN_HEADERS} " )
-	message( STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: Required variable SOCKETCAN_LIBS has not been defined. assuming ${SOCKETCAN_LIBS} " )
+	message( STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: Required variable SOCKETCAN_LIB_FILE has not been defined. assuming ${SOCKETCAN_LIBS} " )
 endif() 
-link_directories( ${SOCKETCAN_PATH_LIBS} )
+link_directories( ${SOCKETCAN_LIB_PATH} )
 
 SET( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/CanInterfaceImplementations/output/)
 

--- a/CanInterfaceImplementations/systec/CMakeLists.txt
+++ b/CanInterfaceImplementations/systec/CMakeLists.txt
@@ -27,7 +27,6 @@ SET( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/CanInterfaceImplementati
 # check if toolchain injection was correct for systec
 # for windows we should use the default systec installer and location
 # for linux we need libsocketcan
-
 if( (NOT DEFINED SYSTEC_LIB_PATH) OR (NOT DEFINED SYSTEC_HEADERS) OR (NOT DEFINED SYSTEC_LIB_FILE)  )
 	message(WARNING "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: Required variable SYSTEC_HEADERS has not been defined." )
 	message(WARNING "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: Required variable SYSTEC_LIB_PATH has not been defined." )

--- a/CanInterfaceImplementations/systec/CMakeLists.txt
+++ b/CanInterfaceImplementations/systec/CMakeLists.txt
@@ -27,30 +27,31 @@ SET( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/CanInterfaceImplementati
 # check if toolchain injection was correct for systec
 # for windows we should use the default systec installer and location
 # for linux we need libsocketcan
-if( NOT DEFINED SYSTEC_LIB_PATH ) 
-	message( STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: Required variable SYSTEC_LIB_FILE has not been defined, take default." )
-	message( STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: Required variable SYSTEC_INC_DIR has not been defined, take default." )
-	message( STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: Required variable SYSTEC_LIB_PATH has not been defined, take default." )
+
+if( (NOT DEFINED SYSTEC_LIB_PATH) OR (NOT DEFINED SYSTEC_HEADERS) OR (NOT DEFINED SYSTEC_LIB_FILE)  )
+	message(WARNING "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: Required variable SYSTEC_HEADERS has not been defined." )
+	message(WARNING "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: Required variable SYSTEC_LIB_PATH has not been defined." )
+	message(WARNING "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: Required variable SYSTEC_LIB_FILE has not been defined." )
+	message(WARNING "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: assuming default locations and libs for systec and windows" )
 	if(WIN32)
-		# using the default installer/location provided by systec for windows
 		SET(SYSTEC_INC_DIR "C:/Program Files (x86)/SYSTEC-electronic/USB-CANmodul Utility Disk/Examples/Include")
 		SET(SYSTEC_LIB_PATH "C:/Program Files (x86)/SYSTEC-electronic/USB-CANmodul Utility Disk/Examples/Lib")
-		if( 64BIT )  
-			SET(SYSTEC_LIB_FILE "USBCAN64.lib")
-		else()
-			SET(SYSTEC_LIB_FILE "USBCAN32.lib")
-		endif()
+		SET(SYSTEC_LIB_FILE "USBCAN64.lib")
+		# for 32 bit 
+		# SET(SYSTEC_LIB_FILE "USBCAN32.lib")
 		message(STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: windows SYSTEC_LIB_PATH= ${SYSTEC_LIB_PATH}]")
+ 		message(STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: windows SYSTEC_HEADERS=  ${SYSTEC_HEADERS}]")
+ 		message(STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: windows SYSTEC_LIB_FILE= ${SYSTEC_LIB_FILE}]")
 	else()
-	    # use socketcan for linux, get sources 
-	    # from i.e. ssh://git@gitlab.cern.ch:7999/mludwig/CAN_libsocketcan.git and build it
-		SET(SYSTEC_HEADERS "/opt/CAN_libsocketcan/include")
-		SET(SYSTEC_PATH_LIBS "/opt/CAN_libsocketcan/src/.libs")
-		SET(SYSTEC_LIB_FILE "libsocketcan.so")
-		message( STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: default path might not work, please get socketcan and correct it." )
-		message(STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: linux SYSTEC_LIB_PATH= ${SYSTEC_LIB_PATH}]")
+	    # since we use socketcan for linux for systec, we are in the wrong directory
+		message( FATAL_ERROR "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: linux uses socketcan (directory sockcan) for systec, you are building the wrong directory." )
 	endif()
-endif()
+else()
+  message(STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: toolchain SYSTEC_LIB_PATH= ${SYSTEC_LIB_PATH}" )
+  message(STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: toolchain SYSTEC_HEADERS=  ${SYSTEC_HEADERS}" )
+  message(STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: toolchain SYSTEC_LIB_FILE = ${SYSTEC_LIB_FILE}" )
+endif() 
+
 
 link_directories( ${SYSTEC_PATH_LIBS} )
 include_directories ( ${SYSTEC_HEADERS} )
@@ -71,13 +72,13 @@ else()
 	target_link_libraries( stcan ${LOGIT_LIB} )
 endif()
 
+message( STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}] systec [BOOST_PATH_LIBS:${BOOST_PATH_LIBS}]" )
+message( STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}] systec [BOOST_HEADERS:${BOOST_HEADERS}]" )
+message( STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}] systec [BOOST_LIBS:${BOOST_LIBS}]" )
+link_directories( ${BOOST_PATH_LIBS} )
+
 target_link_libraries ( stcan ${BOOST_LIBS} ${SYSTEC_LIB_FILE})
 set_property(TARGET stcan PROPERTY POSITION_INDEPENDENT_CODE TRUE)
 set_property(TARGET stcan PROPERTY LINKER_LANGUAGE CXX)
 
-message( STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}] systec [BOOST_PATH_LIBS:${BOOST_PATH_LIBS}]" )
-message( STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}] systec [BOOST_HEADERS:${BOOST_HEADERS}]" )
-message( STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}] systec [BOOST_LIBS:${BOOST_LIBS}]" )
-
-link_directories( ${BOOST_PATH_LIBS} )
 


### PR DESCRIPTION
cleanup of buildchains CMakeLists.txt for libs, lib paths and header paths:
- drop 32BIT/64BIT switch, stay 64BIT default
- can override to 32BIT by toolchain anyway
- VENDOR_LIB_PATH, VENDOR_HEADERS, VENDOR_LIB_FILE adopted everywhere
- proper toolchain injection check with better messages if paths are wrong
