### PR TITLE
Neat versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,8 @@
 #  GNU Lesser General Public Licence for more details <http://www.gnu.org/licenses/>.
 #  
 #
-cmake_minimum_required(VERSION 3.1)
-project( CanModule LANGUAGES C CXX  VERSION 1.1.9.0  ) # sets PROJECT_VERSION etc etc
+cmake_minimum_required(VERSION 3.0)
+project( CanModule LANGUAGES C CXX  VERSION 1.1.8.1  ) # sets PROJECT_VERSION etc etc
 message(STATUS " [${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: CanModule version= ${PROJECT_VERSION}" )
 file(WRITE CanInterface/include/VERSION.h "// VERSION.h - do not edit\n#define CanModule_VERSION \"${PROJECT_VERSION}\"" )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,8 +17,8 @@
 #  GNU Lesser General Public Licence for more details <http://www.gnu.org/licenses/>.
 #  
 #
-cmake_minimum_required(VERSION 2.8)
-project(CanModule)
+cmake_minimum_required(VERSION 3.1)
+project( CanModule LANGUAGES C CXX  VERSION 1.1.9.0  )
 
 SET( DEBUG "false" )
 if( DEFINED DEBUG )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,9 @@
 #  
 #
 cmake_minimum_required(VERSION 3.1)
-project( CanModule LANGUAGES C CXX  VERSION 1.1.9.0  )
+project( CanModule LANGUAGES C CXX  VERSION 1.1.9.0  ) # sets PROJECT_VERSION etc etc
+message(STATUS " [${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: CanModule version= ${PROJECT_VERSION}" )
+file(WRITE CanInterface/include/VERSION.h "// VERSION.h - do not edit\n#define CanModule_VERSION ${PROJECT_VERSION}" )
 
 SET( DEBUG "false" )
 if( DEFINED DEBUG )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@
 cmake_minimum_required(VERSION 3.1)
 project( CanModule LANGUAGES C CXX  VERSION 1.1.9.0  ) # sets PROJECT_VERSION etc etc
 message(STATUS " [${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: CanModule version= ${PROJECT_VERSION}" )
-file(WRITE CanInterface/include/VERSION.h "// VERSION.h - do not edit\n#define CanModule_VERSION ${PROJECT_VERSION}" )
+file(WRITE CanInterface/include/VERSION.h "// VERSION.h - do not edit\n#define CanModule_VERSION \"${PROJECT_VERSION}\"" )
 
 SET( DEBUG "false" )
 if( DEFINED DEBUG )

--- a/CanInterface/include/CCanAccess.h
+++ b/CanInterface/include/CCanAccess.h
@@ -35,6 +35,7 @@
 #include <string>
 #include "CanMessage.h"
 #include "CanStatistics.h"
+#include "VERSION.h"
 #include <LogIt.h>
 
 

--- a/CanInterface/include/CCanAccess.h
+++ b/CanInterface/include/CCanAccess.h
@@ -39,7 +39,6 @@
 #include <LogIt.h>
 
 
-#define VERSION "CanModule version 1.1.8"
 
 /*
  * CCanAccess is an abstract class that defines the interface for controlling a canbus. Different implementations for different hardware and platforms should

--- a/CanInterface/include/CCanAccess.h
+++ b/CanInterface/include/CCanAccess.h
@@ -293,7 +293,7 @@ public:
 			LOG(Log::ERR, _lh) << "can not connect to internal slot " << connectionIndex << " (available slots 0..15)"; }
 		}
 		s_connectionIndex = connectionIndex;
-		LOG(Log::INF, _lh) << "OK connected internal slot" << s_connectionIndex << " to boost signal of this object";
+		LOG(Log::DBG, _lh) << "OK connected internal slot" << s_connectionIndex << " to boost signal of this object";
 	}
 	void disconnectReceptionSlotX( void )
 	{

--- a/CanInterface/include/CCanAccess.h
+++ b/CanInterface/include/CCanAccess.h
@@ -50,7 +50,7 @@ namespace CanModule
 const std::string LogItComponentName = "CanModule";
 #define MLOG(LEVEL,THIS) LOG(Log::LEVEL) << __FUNCTION__ << " " << CanModule::LogItComponentName << " bus= " << THIS->getBusName() << " "
 
-static std::string version(){ return( VERSION ); }
+static std::string version(){ return( CanModule_VERSION ); }
 
 struct CanParameters {
 	long m_lBaudRate;

--- a/CanInterfaceImplementations/CMakeLists.txt
+++ b/CanInterfaceImplementations/CMakeLists.txt
@@ -19,8 +19,8 @@
 #  
 # Authors: Viatcheslav Filimonov, Piotr Nikiel, Ben Farnham, Michael Ludwig ("the quasar team from Atlas and BE-ICS")
 #
-cmake_minimum_required(VERSION 2.8)
-project(CanInterfaceImplementations)
+cmake_minimum_required( VERSION 3.1 )
+project( CanInterfaceImplementations LANGUAGES C CXX  VERSION 1.1.9.0  )
 
 # we have a mock up build without any vendor libs as well, for CI where we don't want to distribute vendors
 message(STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}] building vendors [CANMODULE_BUILD_VENDORS:${CANMODULE_BUILD_VENDORS}]")

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -639,7 +639,7 @@ AnaInt32 AnaCanScan::connectReceptionHandler(){
 	g_AnaCanScanPointerMap[ m_UcanHandle ] = this;
 	setCanHandleInUse( m_UcanHandle, true );
 
-	MLOGANA(INF,this) << "RECEIVE handler looks good, handle= " << m_UcanHandle
+	MLOGANA(DBG,this) << "RECEIVE handler looks good, handle= " << m_UcanHandle
 			<< " CAN port= " << m_canPortNumber
 			<< " ip= " << m_canIPAddress << " Congratulations.";
 	return( anaCallReturn );
@@ -686,12 +686,12 @@ int AnaCanScan::reconnect(){
 
 	switch ( state ){
 	case 2: {
-		MLOGANA(INF,this) << "device is in state connecting, don't try to reconnect for now.";
+		MLOGANA(INF,this) << "device is in state CONNECTING, don't try to reconnect for now, skip.";
 		break;
 	}
 
 	case 3: {
-		MLOGANA(INF,this) << "device is connecting, don't try to reconnect, just skip.";
+		MLOGANA(INF,this) << "device is in state CONNECTED, don't try to reconnect, just skip.";
 		break;
 	}
 	default:
@@ -723,7 +723,7 @@ int AnaCanScan::reconnect(){
 			m_canCloseDevice = false;
 			return(-1);
 		}
-		MLOGANA(INF,this) << "CANOpenDevice m_canPortNumber= " << m_canPortNumber
+		MLOGANA(DBG,this) << "CANOpenDevice m_canPortNumber= " << m_canPortNumber
 				<< " canModuleHandle= " << canModuleHandle
 				<< " ip= " << m_canIPAddress << " timeout= " << m_timeout << " reconnect for SEND looks good";
 
@@ -759,7 +759,7 @@ void AnaCanScan::startAlive( int aliveTime_sec ){
 	if ( anaCallReturn != 0 ){
 		MLOGANA(ERR,this) << "could not start alive mechanism, error=  0x" << hex << anaCallReturn << dec;
 	} else {
-		MLOGANA(INF,this) << "started alive mechanism on handle= " << m_UcanHandle;
+		MLOGANA(DBG,this) << "started alive mechanism on handle= " << m_UcanHandle;
 	}
 }
 

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -207,7 +207,6 @@ bool AnaCanScan::createBus(const string name,const string parameters)
 		std::cout << __FILE__ << " " << __LINE__ << " " << __FUNCTION__
 		<< " could not set LogIt instance" << std::endl;
 
-	logItInstance->registerLoggingComponent( CanModule::LogItComponentName, Log::TRC );
 
 	if (!logItInstance->getComponentHandle(CanModule::LogItComponentName, myHandle))
 		std::cout << __FILE__ << " " << __LINE__ << " " << __FUNCTION__

--- a/CanInterfaceImplementations/anagate/CMakeLists.txt
+++ b/CanInterfaceImplementations/anagate/CMakeLists.txt
@@ -19,8 +19,8 @@
 #  
 # Authors: Viatcheslav Filimonov, Piotr Nikiel, Ben Farnham, Michael Ludwig ("the quasar team from Atlas and BE-ICS")
 #
-cmake_minimum_required(VERSION 2.8)
-project(ancan)
+cmake_minimum_required(VERSION 3.1 )
+project( ancan LANGUAGES C CXX  VERSION 1.1.9.0  )
 
 SET( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/CanInterfaceImplementations/output/)
 

--- a/CanInterfaceImplementations/pkcan/CMakeLists.txt
+++ b/CanInterfaceImplementations/pkcan/CMakeLists.txt
@@ -19,8 +19,8 @@
 #  
 # Authors: Viatcheslav Filimonov, Piotr Nikiel, Ben Farnham, Michael Ludwig ("the quasar team from Atlas and BE-ICS")
 #
-cmake_minimum_required(VERSION 2.8)
-project(pkcan)
+cmake_minimum_required(VERSION 3.1 )
+project( pkcan LANGUAGES C CXX  VERSION 1.1.9.0  )
 
 SET( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/CanInterfaceImplementations/output/)
 

--- a/CanInterfaceImplementations/pkcan/pkcan.cpp
+++ b/CanInterfaceImplementations/pkcan/pkcan.cpp
@@ -138,7 +138,6 @@ bool PKCanScan::createBus(const string name ,const string parameters )
 		std::cout << __FILE__ << " " << __LINE__ << " " << __FUNCTION__
 		<< " could not set LogIt instance" << std::endl;
 
-	logItInstance->registerLoggingComponent( CanModule::LogItComponentName, Log::TRC);
 	if (!logItInstance->getComponentHandle( CanModule::LogItComponentName, myHandle))
 		std::cout << __FILE__ << " " << __LINE__ << " " << __FUNCTION__
 		<< " could not get LogIt component handle for " << LogItComponentName << std::endl;

--- a/CanInterfaceImplementations/sockcan/CMakeLists.txt
+++ b/CanInterfaceImplementations/sockcan/CMakeLists.txt
@@ -19,8 +19,8 @@
 #  
 # Authors: Viatcheslav Filimonov, Piotr Nikiel, Ben Farnham, Michael Ludwig ("the quasar team from Atlas and BE-ICS")
 #
-cmake_minimum_required(VERSION 2.8)
-project(sockcan)
+cmake_minimum_required(VERSION 3.1 )
+project( sockcan LANGUAGES C CXX  VERSION 1.1.9.0  )
 
 if( (NOT DEFINED SOCKETCAN_LIB_PATH) OR (NOT DEFINED SOCKETCAN_HEADERS) OR (NOT DEFINED SOCKETCAN_LIB_FILE)  )
 	SET ( SOCKETCAN_LIB_PATH "/usr/local/lib" )

--- a/CanInterfaceImplementations/sockcan/SockCanScan.cpp
+++ b/CanInterfaceImplementations/sockcan/SockCanScan.cpp
@@ -551,7 +551,6 @@ bool CSockCanScan::createBus(const string name, const string parameters)
 		std::cout << __FILE__ << " " << __LINE__ << " " << __FUNCTION__
 		<< " could not set LogIt instance" << std::endl;
 
-	logItInstance->registerLoggingComponent( CanModule::LogItComponentName, Log::TRC );
 	if (!logItInstance->getComponentHandle(CanModule::LogItComponentName, myHandle))
 		std::cout << __FILE__ << " " << __LINE__ << " " << __FUNCTION__
 		<< " could not get LogIt component handle for " << LogItComponentName << std::endl;

--- a/CanInterfaceImplementations/sockcan/SockCanScan.cpp
+++ b/CanInterfaceImplementations/sockcan/SockCanScan.cpp
@@ -212,7 +212,6 @@ void* CSockCanScan::CanScanControlThread(void *p_voidSockCanScan)
 							// Stopping bus.";
 							// p_sockCanScan->stopBus();
 						} else {
-							MLOGSOCK(INF,p_sockCanScan) << "Socket closed"<< " tid= " << _tid;
 							sock = -1;
 						}
 					}
@@ -228,10 +227,10 @@ void* CSockCanScan::CanScanControlThread(void *p_voidSockCanScan)
 						if ((sock = p_sockCanScan->openCanPort()) < 0) {
 							MLOGSOCK(ERR,p_sockCanScan) << " tid= " << _tid << "openCanPort() failed.";
 						} else {
-							MLOGSOCK(INF,p_sockCanScan) << " tid= " << _tid << "Port reopened.";
+							// MLOGSOCK(INF,p_sockCanScan) << " tid= " << _tid << "Port reopened.";
 						}
 					} else {
-						MLOGSOCK(INF,p_sockCanScan) << " tid= " << _tid << "Leaving Port closed, not needed any more.";
+						// MLOGSOCK(INF,p_sockCanScan) << " tid= " << _tid << "Leaving Port closed, not needed any more.";
 					}
 				} // do...while ... we still have an error
 				while ( p_sockCanScan->m_CanScanThreadShutdownFlag && sock < 0 );
@@ -246,7 +245,7 @@ void* CSockCanScan::CanScanControlThread(void *p_voidSockCanScan)
 
 
 			if (numberOfReadBytes <(int) sizeof(struct can_frame)) {
-				MLOGSOCK( INF, p_sockCanScan ) << p_sockCanScan->m_channelName.c_str() << " incomplete frame received, numberOfReadBytes=[" << numberOfReadBytes << "]";
+				MLOGSOCK( WRN, p_sockCanScan ) << p_sockCanScan->m_channelName.c_str() << " incomplete frame received, numberOfReadBytes=[" << numberOfReadBytes << "]";
 
 				// we just report the error and continue the thread normally
 				continue;
@@ -299,7 +298,7 @@ void* CSockCanScan::CanScanControlThread(void *p_voidSockCanScan)
 					<< " socket= " << p_sockCanScan->m_sock << " (got nothing)"<< " tid= " << _tid;
 		}
 	}
-	MLOGSOCK(INF,p_sockCanScan) << "main loop of SockCanScan terminated." << " tid= " << _tid;
+	// MLOGSOCK(INF,p_sockCanScan) << "main loop of SockCanScan terminated." << " tid= " << _tid;
 	pthread_exit(NULL);
 }
 

--- a/CanInterfaceImplementations/systec/CMakeLists.txt
+++ b/CanInterfaceImplementations/systec/CMakeLists.txt
@@ -19,8 +19,8 @@
 #  
 # Authors: Viatcheslav Filimonov, Piotr Nikiel, Ben Farnham, Michael Ludwig ("the quasar team from Atlas and BE-ICS")
 #
-cmake_minimum_required(VERSION 2.8)
-project(stcan)
+cmake_minimum_required(VERSION 3.1 )
+project( stcan LANGUAGES C CXX  VERSION 1.1.9.0  )
 
 SET( CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/CanInterfaceImplementations/output/)
 

--- a/CanInterfaceImplementations/systec/STCanScan.cpp
+++ b/CanInterfaceImplementations/systec/STCanScan.cpp
@@ -148,7 +148,6 @@ bool STCanScan::createBus(const string name,const string parameters)
 		std::cout << __FILE__ << " " << __LINE__ << " " << __FUNCTION__
 		<< " could not set LogIt instance" << std::endl;
 
-	logItInstance->registerLoggingComponent( CanModule::LogItComponentName, Log::TRC );
 	if (!logItInstance->getComponentHandle(CanModule::LogItComponentName, myHandle))
 		std::cout << __FILE__ << " " << __LINE__ << " " << __FUNCTION__
 		<< " could not get LogIt component handle for " << LogItComponentName << std::endl;

--- a/CanInterfaceImplementations/unitTestMockUpImplementation/CMakeLists.txt
+++ b/CanInterfaceImplementations/unitTestMockUpImplementation/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8)
-project(MockUpCanImplementationcan)
+cmake_minimum_required(VERSION 3.1 )
+project( MockUpCanImplementationcan LANGUAGES C CXX  VERSION 1.1.9.0  )
 
 message(STATUS "file [${CMAKE_CURRENT_LIST_FILE}]: STANDALONE_BUILD [${STANDALONE_BUILD}]")
 message(STATUS "file [${CMAKE_CURRENT_LIST_FILE}]: Using boost libraries: BOOST_LIBS [${BOOST_LIBS}]")  

--- a/CanLibLoader/src/CanLibLoader.cpp
+++ b/CanLibLoader/src/CanLibLoader.cpp
@@ -70,8 +70,9 @@ namespace CanModule
 		}
 
 		//The Logit instance of the executable is handled to the DLL at this point, so the instance is shared.
-		tcca->initialiseLogging( LogItInstance::getInstance() );
-		//LOG(Log::DBG, lh ) << __FUNCTION__ << " Logging initialized OK";
+		LogItInstance *logInstance = LogItInstance::getInstance() ;
+		tcca->initialiseLogging( logInstance );
+		logInstance->registerLoggingComponent( CanModule::LogItComponentName, Log::TRC );
 
 		LOG(Log::DBG, lh ) << __FUNCTION__ << " calling createBus. name= " << name << " parameters= " << parameters;
 		/** @param name: Name of the can bus channel. The specific mapping will change depending on the interface used. For example, accessing channel 0 for the

--- a/CanModuleTest/CMakeLists.txt
+++ b/CanModuleTest/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 2.8)
-project(CanModuleTest)
+cmake_minimum_required(VERSION 3.1 )
+project( CanModuleTest LANGUAGES C CXX  VERSION 1.1.9.0  )
 find_package(Threads REQUIRED)
 
 function ( clone_googletest GOOGLETEST_VERSION)


### PR DESCRIPTION
switch to minimum cmake 3.0 to have proper versioning through the build chain, also for the bins/libs/archives
* version number like "1.1.8.1" edited in the top level CMakeLists.txt, and thats the ONLY place
* VERSION.h is generated by cmake accordingly and included
* VERSION.h is included in the source and produces compiled timestamp  & version (actually: parsed)
