### PR TITLE
Swdisconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 1.1.9.5
+- disconnect and reconnect on the same bus by software: connection map management corrected
+- double-create of one bus protected
+- double-close of one bus protected
+- works for (systec and peak) socketcan@linux
+
+
 ## 1.1.9.4 [14.oct.2019]
 - sync flag suppressed
 - hi speed to true as default for anagate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - double-create of one bus protected
 - double-close of one bus protected
 - works for (systec and peak) socketcan@linux
+- increased anagate open can bus timeout from 6 to 12 seconds
 
 
 ## 1.1.9.4 [14.oct.2019]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - disconnect and reconnect on the same bus by software: connection map management corrected
 - double-create of one bus protected
 - double-close of one bus protected
-- works for (systec and peak) socketcan@linux
+- works for systec, peak and anagate @linux
 - increased anagate open can bus timeout from 6 to 12 seconds
-
+- force a delay of 7 sec. after anagate close bus to avoid fw crash too soon
 
 ## 1.1.9.4 [14.oct.2019]
 - sync flag suppressed

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -79,7 +79,7 @@ AnaCanScan::AnaCanScan():
 				m_busName(""),
 				m_busParameters(""),
 				m_UcanHandle(0),
-				m_timeout ( 6000 )
+				m_timeout ( 12000 )
 {
 	m_statistics.beginNewRun();
 }
@@ -339,7 +339,7 @@ int AnaCanScan::openCanPort()
 	} else {
 		//Otherwise we create it.
 		MLOGANA(DBG, this) << "Will call CANOpenDevice with parameters m_canHandleNumber:[" << m_canPortNumber << "], m_canIPAddress:[" << m_canIPAddress << "]";
-		anaCallReturn = CANOpenDevice(&canModuleHandle, FALSE, TRUE, m_canPortNumber, m_canIPAddress.c_str(),m_timeout);
+		anaCallReturn = CANOpenDevice(&canModuleHandle, FALSE, TRUE, m_canPortNumber, m_canIPAddress.c_str(), m_timeout);
 		if (anaCallReturn != 0) {
 			// fill out initialisation struct
 			MLOGANA(ERR,this) << "Error in CANOpenDevice, return code = [" << anaCallReturn << "]";

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -94,9 +94,11 @@ AnaCanScan::~AnaCanScan()
 
 void AnaCanScan::stopBus ()
 {
-	MLOGANA(TRC,this) << __FUNCTION__ << " m_busName= " <<  m_busName;
+	MLOGANA(TRC,this) << __FUNCTION__ << " m_busName= " <<  m_busName << " m_canPortNumber= " << m_canPortNumber;
 	CANSetCallback(m_UcanHandle, 0);
 	CANCloseDevice(m_UcanHandle);
+
+	setCanHandleInUse(m_canPortNumber,false);
 
 
 #if 0

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -116,13 +116,13 @@ void AnaCanScan::stopBus ()
 		MLOGANA(DBG,this) << " not joining threads... bus does not exist";
 	}
 #endif
-	MLOGANA(Log::TRC, this ) << " imposing a delay of 7 seconds before continuing";
+	MLOGANA(TRC, this ) << " imposing a delay of 7 seconds before continuing";
 	{
 		struct timespec tim, tim2;
 		tim.tv_sec = 7;
 		tim.tv_nsec = 0;
 		if(nanosleep(&tim , &tim2) < 0 ) {
-			MLOGANA(Log::ERR, lh ) << " Waiting failed (nanosleep)";
+			MLOGANA(ERR, this ) << " Waiting failed (nanosleep)";
 		}
 	}
 	MLOGANA(TRC,this) << " finished";

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -107,7 +107,6 @@ void AnaCanScan::stopBus ()
 	boost::this_thread::sleep_for(boost::chrono::milliseconds( 7000 ));
 #endif
 	MLOGANA(TRC,this) << " finished";
-
 }
 
 

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -116,7 +116,16 @@ void AnaCanScan::stopBus ()
 		MLOGANA(DBG,this) << " not joining threads... bus does not exist";
 	}
 #endif
-	MLOGANA(TRC,this) << __FUNCTION__ << " finished";
+	MLOGANA(Log::TRC, this ) << " imposing a delay of 7 seconds before continuing";
+	{
+		struct timespec tim, tim2;
+		tim.tv_sec = 7;
+		tim.tv_nsec = 0;
+		if(nanosleep(&tim , &tim2) < 0 ) {
+			MLOGANA(Log::ERR, lh ) << " Waiting failed (nanosleep)";
+		}
+	}
+	MLOGANA(TRC,this) << " finished";
 }
 
 

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -101,33 +101,8 @@ void AnaCanScan::stopBus ()
 	setCanHandleInUse(m_canPortNumber,false);
 	eraseReceptionHandlerFromMap( m_UcanHandle );
 
-#if 0
-	// notify the thread that it should finish.
-	m_CanScanThreadRunEnableFlag = false;
-	MLOGANA(DBG,this) << " try joining threads...";
-
-	std::map<string, string>::iterator it = CSockCanScan::m_busMap.find( m_busName );
-	if (it != CSockCanScan::m_busMap.end()) {
-		pthread_join( m_hCanScanThread, 0 );
-		m_idCanScanThread = 0;
-		CSockCanScan::m_busMap.erase ( it );
-		m_busName = "nobus";
-	} else {
-		MLOGANA(DBG,this) << " not joining threads... bus does not exist";
-	}
-#endif
-#ifdef _WIN32
-#else
 	MLOGANA(TRC, this ) << " imposing a delay of 7 seconds before continuing";
-	{
-		struct timespec tim, tim2;
-		tim.tv_sec = 7;
-		tim.tv_nsec = 0;
-		if(nanosleep(&tim , &tim2) < 0 ) {
-			MLOGANA(ERR, this ) << " Waiting failed (nanosleep)";
-		}
-	}
-#endif
+	boost::this_thread::sleep_for(boost::chrono::milliseconds( 7000 ));
 	MLOGANA(TRC,this) << " finished";
 
 }

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -111,8 +111,6 @@ void AnaCanScan::stopBus ()
 }
 
 
-
-
 /* static */ void AnaCanScan::setIpReconnectInProgress( string ip, bool flag ){
 	anagateReconnectMutex.lock();
 	std::map<string,bool>::iterator it = AnaCanScan::reconnectInProgress_map.find( ip );
@@ -251,7 +249,7 @@ bool AnaCanScan::createBus(const string name,const string parameters)
 
 
 /**
- * decode the name, parameter and return the port to the configured module
+ * decode the name, parameter and return the port of the configured module
  */
 int AnaCanScan::configureCanBoard(const string name,const string parameters)
 {
@@ -312,8 +310,7 @@ int AnaCanScan::configureCanBoard(const string name,const string parameters)
 }
 
 /**
- *
- * Obtains a Anagate canport and opens it.
+ * Obtains an Anagate canport and opens it.
  *  The name of the port and parameters should have been specified by preceding call to configureCanboard()
  *  @returns less than zero in case of error, otherwise success
  *
@@ -344,7 +341,6 @@ int AnaCanScan::openCanPort()
 	setCanHandleInUse(m_canPortNumber,true);
 
 	// initialize CAN interface
-
 	MLOGANA(TRC,this) << "calling CANSetGlobals with m_lBaudRate= "
 			<< m_CanParameters.m_lBaudRate
 			<< " m_iOperationMode= " << m_CanParameters.m_iOperationMode
@@ -675,10 +671,9 @@ void AnaCanScan::eraseReceptionHandlerFromMap( AnaInt32 h ){
 	std::map<AnaInt32, AnaCanScan *>::iterator it = g_AnaCanScanPointerMap.find( h );
 	if (it != g_AnaCanScanPointerMap.end()) {
 		g_AnaCanScanPointerMap.erase ( it );
-//		m_busName = "nobus";
+		m_busName = "nobus";
 	} else {
 		MLOGANA(DBG,this) << " handler " << h << " not found in map, not erased";
-
 	}
 }
 

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -101,8 +101,11 @@ void AnaCanScan::stopBus ()
 	setCanHandleInUse(m_canPortNumber,false);
 	eraseReceptionHandlerFromMap( m_UcanHandle );
 
+#ifdef _WIN32
+#else
 	MLOGANA(TRC, this ) << " imposing a delay of 7 seconds before continuing";
 	boost::this_thread::sleep_for(boost::chrono::milliseconds( 7000 ));
+#endif
 	MLOGANA(TRC,this) << " finished";
 
 }

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -235,7 +235,6 @@ bool AnaCanScan::createBus(const string name,const string parameters)
 	//LOG(Log::TRC, myHandle) << __FUNCTION__ << " " __FILE__ << " " << __LINE__;
 	AnaCanScan::s_logItHandleAnagate = myHandle;
 
-	m_sBusName = name;
 	MLOGANA(DBG, this) << " parameters= " << parameters;
 	int returnCode = configureCanBoard(name, parameters);
 	if ( returnCode < 0 ) {

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -99,7 +99,7 @@ void AnaCanScan::stopBus ()
 	CANCloseDevice(m_UcanHandle);
 
 	setCanHandleInUse(m_canPortNumber,false);
-
+	eraseReceptionHandlerFromMap( m_UcanHandle );
 
 #if 0
 	// notify the thread that it should finish.
@@ -676,6 +676,17 @@ AnaInt32 AnaCanScan::connectReceptionHandler(){
 	return( anaCallReturn );
 }
 
+
+void AnaCanScan::eraseReceptionHandlerFromMap( AnaInt32 h ){
+	std::map<string, string>::iterator it = AnaCanScan::g_AnaCanScanPointerMap.find( h );
+	if (it != AnaCanScan::g_AnaCanScanPointerMap.end()) {
+		AnaCanScan::g_AnaCanScanPointerMap.erase ( it );
+//		m_busName = "nobus";
+	} else {
+		MLOGANA(DBG,this) << " handler " << h << " not found in map, not erased;
+
+	}
+}
 
 /**
  * we try to reconnect one port after a power loss, and we should do this for all ports

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -683,7 +683,7 @@ void AnaCanScan::eraseReceptionHandlerFromMap( AnaInt32 h ){
 		AnaCanScan::g_AnaCanScanPointerMap.erase ( it );
 //		m_busName = "nobus";
 	} else {
-		MLOGANA(DBG,this) << " handler " << h << " not found in map, not erased;
+		MLOGANA(DBG,this) << " handler " << h << " not found in map, not erased";
 
 	}
 }

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -28,11 +28,12 @@
 
 #include <time.h>
 #include <string.h>
-
 #include <map>
 #include <LogIt.h>
 #include <sstream>
 #include <iostream>
+#include <boost/thread/thread.hpp>
+
 #include "CanModuleUtils.h"
 
 #ifdef _WIN32

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -678,9 +678,9 @@ AnaInt32 AnaCanScan::connectReceptionHandler(){
 
 
 void AnaCanScan::eraseReceptionHandlerFromMap( AnaInt32 h ){
-	std::map<string, string>::iterator it = AnaCanScan::g_AnaCanScanPointerMap.find( h );
-	if (it != AnaCanScan::g_AnaCanScanPointerMap.end()) {
-		AnaCanScan::g_AnaCanScanPointerMap.erase ( it );
+	std::map<string, string>::iterator it = g_AnaCanScanPointerMap.find( h );
+	if (it != g_AnaCanScanPointerMap.end()) {
+		g_AnaCanScanPointerMap.erase ( it );
 //		m_busName = "nobus";
 	} else {
 		MLOGANA(DBG,this) << " handler " << h << " not found in map, not erased";

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -89,11 +89,40 @@ AnaCanScan::AnaCanScan():
  */
 AnaCanScan::~AnaCanScan()
 {
-	LOG(Log::TRC, AnaCanScan::s_logItHandleAnagate ) << "Closing down Anagate Can Scan component";
+	stopBus();
+
+}
+
+/**
+ * notify the main thread to finish and delete the bus from the map of connections
+ */
+void AnaCanScan::stopBus ()
+{
+	MLOGANA(TRC,this) << __FUNCTION__ << " m_busName= " <<  m_busName;
 	CANSetCallback(m_UcanHandle, 0);
 	CANCloseDevice(m_UcanHandle);
-	LOG(Log::TRC, AnaCanScan::s_logItHandleAnagate ) << "Anagate Can Scan component closed successfully";
+
+
+#if 0
+	// notify the thread that it should finish.
+	m_CanScanThreadRunEnableFlag = false;
+	MLOGANA(DBG,this) << " try joining threads...";
+
+	std::map<string, string>::iterator it = CSockCanScan::m_busMap.find( m_busName );
+	if (it != CSockCanScan::m_busMap.end()) {
+		pthread_join( m_hCanScanThread, 0 );
+		m_idCanScanThread = 0;
+		CSockCanScan::m_busMap.erase ( it );
+		m_busName = "nobus";
+	} else {
+		MLOGANA(DBG,this) << " not joining threads... bus does not exist";
+	}
+#endif
+	MLOGANA(TRC,this) << __FUNCTION__ << " finished";
 }
+
+
+
 
 /* static */ void AnaCanScan::setIpReconnectInProgress( string ip, bool flag ){
 	std::map<string,bool>::iterator it = AnaCanScan::reconnectInProgress_map.find( ip );

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -276,7 +276,7 @@ int AnaCanScan::configureCanBoard(const string name,const string parameters)
 			// or by decoding. They are always used.
 		} else {
 			MLOGANA(ERR, this) << "Error while parsing parameters: this syntax is incorrect: [" << parameters << "]";
-			MLOGANA(ERR, this) << "you need up to 5 numbers separated by whitespaces, i.e. \"125000 0 0 0 0 0\" \"p0 p1 p2 p3 p4\"";
+			MLOGANA(ERR, this) << "you need up to 5 numbers separated by whitespaces, i.e. \"125000 0 0 0 0\" \"p0 p1 p2 p3 p4\"";
 			MLOGANA(ERR, this) << "  p0 = baud rate, 125000 or whatever the module supports";
 			MLOGANA(ERR, this) << "  p1 = operation mode";
 			MLOGANA(ERR, this) << "  p2 = termination";

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -117,7 +117,6 @@ void AnaCanScan::stopBus ()
 	}
 #endif
 #ifdef _WIN32
-	// maybe no delay neccessary ?
 #else
 	MLOGANA(TRC, this ) << " imposing a delay of 7 seconds before continuing";
 	{

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -116,6 +116,9 @@ void AnaCanScan::stopBus ()
 		MLOGANA(DBG,this) << " not joining threads... bus does not exist";
 	}
 #endif
+#ifdef _WIN32
+	// maybe no delay neccessary ?
+#else
 	MLOGANA(TRC, this ) << " imposing a delay of 7 seconds before continuing";
 	{
 		struct timespec tim, tim2;
@@ -125,7 +128,9 @@ void AnaCanScan::stopBus ()
 			MLOGANA(ERR, this ) << " Waiting failed (nanosleep)";
 		}
 	}
+#endif
 	MLOGANA(TRC,this) << " finished";
+
 }
 
 

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -113,6 +113,7 @@ void AnaCanScan::stopBus ()
 
 
 /* static */ void AnaCanScan::setIpReconnectInProgress( string ip, bool flag ){
+	anagateReconnectMutex.lock();
 	std::map<string,bool>::iterator it = AnaCanScan::reconnectInProgress_map.find( ip );
 
 	if ( flag ){
@@ -126,14 +127,17 @@ void AnaCanScan::stopBus ()
 			AnaCanScan::reconnectInProgress_map.erase( it );
 		}
 	}
+	anagateReconnectMutex.unlock();
 }
 
 /* static */ bool AnaCanScan::isIpReconnectInProgress( string ip ){
+	anagateReconnectMutex.lock();
 	std::map<string,bool>::iterator it = AnaCanScan::reconnectInProgress_map.find( ip );
 	if ( it == AnaCanScan::reconnectInProgress_map.end() )
 		return( false );
 	else
 		return( true );
+	anagateReconnectMutex.unlock();
 }
 
 

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -678,7 +678,7 @@ AnaInt32 AnaCanScan::connectReceptionHandler(){
 
 
 void AnaCanScan::eraseReceptionHandlerFromMap( AnaInt32 h ){
-	std::map<string, string>::iterator it = g_AnaCanScanPointerMap.find( h );
+	std::map<AnaInt32, AnaCanScan *>::iterator it = g_AnaCanScanPointerMap.find( h );
 	if (it != g_AnaCanScanPointerMap.end()) {
 		g_AnaCanScanPointerMap.erase ( it );
 //		m_busName = "nobus";

--- a/CanInterfaceImplementations/anagate/AnaCanScan.cpp
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.cpp
@@ -90,12 +90,8 @@ AnaCanScan::AnaCanScan():
 AnaCanScan::~AnaCanScan()
 {
 	stopBus();
-
 }
 
-/**
- * notify the main thread to finish and delete the bus from the map of connections
- */
 void AnaCanScan::stopBus ()
 {
 	MLOGANA(TRC,this) << __FUNCTION__ << " m_busName= " <<  m_busName;

--- a/CanInterfaceImplementations/anagate/AnaCanScan.h
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.h
@@ -24,7 +24,6 @@
 #ifndef CCANANASCAN_H_
 #define CCANANASCAN_H_
 
-#include <boost/thread/thread.hpp> // just needed for the boost sleep
 
 #include <string>
 #include "CanStatistics.h"

--- a/CanInterfaceImplementations/anagate/AnaCanScan.h
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.h
@@ -119,6 +119,7 @@ private:
 	int reconnect();
 	bool errorCodeToString(long error, char message[]);
 	void stopBus( void );
+	void eraseReceptionHandlerFromMap( AnaInt32 h );
 
 };
 

--- a/CanInterfaceImplementations/anagate/AnaCanScan.h
+++ b/CanInterfaceImplementations/anagate/AnaCanScan.h
@@ -118,6 +118,8 @@ private:
 	int openCanPort();
 	int reconnect();
 	bool errorCodeToString(long error, char message[]);
+	void stopBus( void );
+
 };
 
 #endif //CCANANASCAN_H_

--- a/CanInterfaceImplementations/pkcan/pkcan.cpp
+++ b/CanInterfaceImplementations/pkcan/pkcan.cpp
@@ -73,7 +73,9 @@ void PKCanScan::stopBus ()
 	// MLOGPK(DBG, this ) << __FUNCTION__ << " m_busName= " <<  m_busName ;
 	std::cout << __FILE__ << " " << __LINE__ << " " << __FUNCTION__ << " m_busName= " <<  m_busName << std::endl;
 
-	CAN_Uninitialize(m_canObjHandler);
+	MLOGPK(TRC, this) << "calling CAN_Uninitialize";
+	TPCANStatus tpcanStatus = CAN_Uninitialize(m_canObjHandler);
+	MLOGPK(TRC, this) << "CAN_Uninitialize returns " << (int) tpcanStatus;
 
 
 	m_CanScanThreadRunEnableFlag = false;

--- a/CanInterfaceImplementations/pkcan/pkcan.cpp
+++ b/CanInterfaceImplementations/pkcan/pkcan.cpp
@@ -213,6 +213,7 @@ bool PKCanScan::createBus(const string name ,const string parameters )
 		return false;
 	}
 
+	bool skipMainThreadCreation = false;
 	{
 		peakReconnectMutex.lock();
 		// debug bus map
@@ -221,7 +222,6 @@ bool PKCanScan::createBus(const string name ,const string parameters )
 		}
 
 		// dont create a main thread for the same bus twice
-		bool skipMainThreadCreation = false;
 		std::map<string, string>::iterator it = PKCanScan::m_busMap.find( name );
 		if (it == PKCanScan::m_busMap.end()) {
 			PKCanScan::m_busMap.insert ( std::pair<string, string>(name, parameters) );

--- a/CanInterfaceImplementations/pkcan/pkcan.cpp
+++ b/CanInterfaceImplementations/pkcan/pkcan.cpp
@@ -70,7 +70,7 @@ PKCanScan::~PKCanScan()
  */
 void PKCanScan::stopBus ()
 {
-	MLOGPK(DBG,s_logItHandlePk) << __FUNCTION__ << " m_busName= " <<  m_busName ;
+	MLOGPK(DBG, PKCanScan::s_logItHandlePk ) << __FUNCTION__ << " m_busName= " <<  m_busName ;
 	CAN_Uninitialize(m_canObjHandler);
 
 	// notify the thread that it should finish.
@@ -82,7 +82,7 @@ void PKCanScan::stopBus ()
 	if (it != PKCanScan::m_busMap.end()) {
 
 		// windows does not have pthread_join
-		pthread_join( m_hCanScanThread, 0 );
+		//pthread_join( m_hCanScanThread, 0 );
 		m_idCanScanThread = 0;
 		PKCanScan::m_busMap.erase ( it );
 		m_busName = "nobus";
@@ -138,10 +138,6 @@ DWORD WINAPI PKCanScan::CanScanControlThread(LPVOID pCanScan)
 			}
 		}
 	}
-	MLOGPK(TRC, pkCanScanPointer) << "uninitializing CAN...";
-	//	CloseHandle(m_ReadEvent);
-	CAN_Uninitialize(m_canObjHandler);
-
 	MLOGPK(TRC, pkCanScanPointer) << "exiting thread...";
 	ExitThread(0);
 	return 0;

--- a/CanInterfaceImplementations/pkcan/pkcan.cpp
+++ b/CanInterfaceImplementations/pkcan/pkcan.cpp
@@ -70,15 +70,15 @@ PKCanScan::~PKCanScan()
  */
 bool PKCanScan::stopBus ()
 {
-	MLOGPK(DBG,this) << __FUNCTION__ << " m_busName= " <<  m_busName << " m_canObjHandler= 0x"
+	MLOGPK(DBG,pkCanScanPointer) << __FUNCTION__ << " m_busName= " <<  m_busName << " m_canObjHandler= 0x"
 			<< hex << m_canObjHandler << dec;
 	CAN_Uninitialize(m_canObjHandler);
 
 	// notify the thread that it should finish.
 	m_CanScanThreadRunEnableFlag = false;
-	MLOGPK(DBG,this) << " try joining threads...";
+	MLOGPK(DBG,pkCanScanPointer) << " try joining threads...";
 
-#if 0
+//#if 0
 	std::map<string, string>::iterator it = PKCanScan::m_busMap.find( m_busName );
 	if (it != PKCanScan::m_busMap.end()) {
 		pthread_join( m_hCanScanThread, 0 );
@@ -86,10 +86,10 @@ bool PKCanScan::stopBus ()
 		PKCanScan::m_busMap.erase ( it );
 		m_busName = "nobus";
 	} else {
-		MLOGPK(DBG,this) << " not joining threads... bus does not exist";
+		MLOGPK(DBG,pkCanScanPointer) << " not joining threads... bus does not exist";
 	}
-#endif
-	MLOGPK(DBG,this) << "stopBus() finished";
+//#endif
+	MLOGPK(DBG,pkCanScanPointer) << "stopBus() finished";
 	return true;
 }
 

--- a/CanInterfaceImplementations/pkcan/pkcan.cpp
+++ b/CanInterfaceImplementations/pkcan/pkcan.cpp
@@ -280,7 +280,7 @@ bool PKCanScan::configureCanboard(const string name,const string parameters)
 	{
 		//numPar = sscanf_s(canpars, "%d %d %d %d %d %d", &parametersBaudRate, &parametersTseg1, &parametersTseg2, &parametersSjw, &parametersNoSamp, &parametersSyncmode);
 		//Get the can object handler
-		m_canObjHandler = getHandle(vectorString[1].c_str());
+		m_canObjHandler = getHandle(humanReadableCode /* vectorString[1].c_str() */ );
 		//Process the baudRate if needed
 		if (m_CanParameters.m_iNumberOfDetectedParameters == 1)
 		{
@@ -348,6 +348,8 @@ bool PKCanScan::configureCanboard(const string name,const string parameters)
 			break;
 		}
 		Sleep( 1000 ); // 1000 ms
+		tpcanStatus = CAN_Uninitialize( m_canObjHandler );
+		Sleep( 3000 ); // 3000 ms
 		counter--;
 	}
 

--- a/CanInterfaceImplementations/pkcan/pkcan.cpp
+++ b/CanInterfaceImplementations/pkcan/pkcan.cpp
@@ -169,8 +169,6 @@ bool PKCanScan::createBus(const string name ,const string parameters )
  */
 bool PKCanScan::configureCanboard(const string name,const string parameters)
 {
-	std::cout << __FILE__ << " " << __LINE__ << " " << __FUNCTION__ << " name= " << name << " parameters= " << parameters << std::endl;
-
 	m_sBusName = name;
 	m_baudRate = PCAN_BAUD_125K;
 

--- a/CanInterfaceImplementations/pkcan/pkcan.cpp
+++ b/CanInterfaceImplementations/pkcan/pkcan.cpp
@@ -73,15 +73,12 @@ void PKCanScan::stopBus ()
 	// MLOGPK(DBG, this ) << __FUNCTION__ << " m_busName= " <<  m_busName ;
 	std::cout << __FILE__ << " " << __LINE__ << " " << __FUNCTION__ << " m_busName= " <<  m_busName << std::endl;
 
-	MLOGPK(TRC, this) << "calling CAN_Uninitialize";
-	TPCANStatus tpcanStatus = CAN_Uninitialize(m_canObjHandler);
-	MLOGPK(TRC, this) << "CAN_Uninitialize returns " << (int) tpcanStatus;
-
-
 	m_CanScanThreadRunEnableFlag = false;
 	MLOGPK(DBG,this) << " try finishing thread...";
 
-	Sleep(2); // and wait a bit for the thread to die
+	MLOGPK(TRC, this) << "calling CAN_Uninitialize";
+	TPCANStatus tpcanStatus = CAN_Uninitialize(m_canObjHandler);
+	MLOGPK(TRC, this) << "CAN_Uninitialize returns " << (int) tpcanStatus;
 
 	// debug bus map
 	for (std::map<string, string>::iterator it = PKCanScan::m_busMap.begin(); it != PKCanScan::m_busMap.end(); ++it){
@@ -97,6 +94,7 @@ void PKCanScan::stopBus ()
 		m_idCanScanThread = 0;
 		PKCanScan::m_busMap.erase ( it );
 		m_busName = "nobus";
+		MLOGPK(TRC,this) << " bus " << m_busName << " erased from map, OK";
 	} else {
 		MLOGPK(DBG,this) << " bus " << m_busName << " does not exist";
 	}
@@ -105,6 +103,7 @@ void PKCanScan::stopBus ()
 	for (std::map<string, string>::iterator it = PKCanScan::m_busMap.begin(); it != PKCanScan::m_busMap.end(); ++it){
 		std::cout << __FILE__ << " " << __LINE__ << " after " << it->first << " => " << it->second << std::endl;
 	}
+	Sleep(2); // and wait a bit for the thread to die
 
 	MLOGPK(DBG,this) << "stopBus() finished";
 }

--- a/CanInterfaceImplementations/pkcan/pkcan.cpp
+++ b/CanInterfaceImplementations/pkcan/pkcan.cpp
@@ -256,7 +256,9 @@ bool PKCanScan::configureCanboard(const string name,const string parameters)
 	/**
 	 * fixed datarate modules (classical CAN), plug and play
 	 */
+	MLOGPK(TRC, this) << "calling CAN_Initialize";
 	TPCANStatus tpcanStatus = CAN_Initialize(m_canObjHandler, m_baudRate );
+	MLOGPK(TRC, this) << "CAN_Initialize returns " << (int) tpcanStatus;
 
 	/** fixed data rate, non plug-and-play
 	 * static TPCANStatus Initialize(

--- a/CanInterfaceImplementations/pkcan/pkcan.cpp
+++ b/CanInterfaceImplementations/pkcan/pkcan.cpp
@@ -234,7 +234,7 @@ bool PKCanScan::createBus(const string name ,const string parameters )
 		for (std::map<string, string>::iterator it = PKCanScan::m_busMap.begin(); it != PKCanScan::m_busMap.end(); ++it){
 			std::cout << __FILE__ << " " << __LINE__ << " after " << it->first << " => " << it->second << std::endl;
 		}
-		peakReconnectMutex.lock();
+		peakReconnectMutex.unlock();
 	}
 	if ( skipMainThreadCreation ){
 		MLOGPK(TRC, this) << "Re-using main thread m_idCanScanThread= " << m_idCanScanThread;

--- a/CanInterfaceImplementations/pkcan/pkcan.cpp
+++ b/CanInterfaceImplementations/pkcan/pkcan.cpp
@@ -70,8 +70,7 @@ PKCanScan::~PKCanScan()
  */
 void PKCanScan::stopBus ()
 {
-	MLOGPK(DBG,s_logItHandlePk) << __FUNCTION__ << " m_busName= " <<  m_busName << " m_canObjHandler= 0x"
-			<< hex << m_canObjHandler << dec;
+	MLOGPK(DBG,s_logItHandlePk) << __FUNCTION__ << " m_busName= " <<  m_busName ;
 	CAN_Uninitialize(m_canObjHandler);
 
 	// notify the thread that it should finish.
@@ -185,7 +184,7 @@ bool PKCanScan::createBus(const string name ,const string parameters )
 	PKCanScan::s_logItHandlePk = myHandle;
 	MLOGPK(DBG, this) << " name= " << name << " parameters= " << parameters << ", configuring CAN board";
 
-	m_sBusName = name;
+	m_sBusName = name; // maybe this can be cleaned up: we have m_busName already
 	//We configure the canboard
 	if ( !configureCanboard(name,parameters) ) {
 		//If we can't initialise the canboard, the thread is not started at all

--- a/CanInterfaceImplementations/pkcan/pkcan.cpp
+++ b/CanInterfaceImplementations/pkcan/pkcan.cpp
@@ -195,7 +195,9 @@ bool PKCanScan::configureCanboard(const string name,const string parameters)
 	string interface = "USB";
 	string humanReadableCode = interface + channel.str();
 	m_canObjHandler = getHandle( humanReadableCode.c_str() );
-	MLOGPK( DBG, this ) << "PEAK handle for vectorString[1]= " << vectorString[1] << " is code= 0x" <<hex <<  m_canObjHandler << dec << std::endl;
+	MLOGPK( DBG, this ) << "PEAK handle for vectorString[1]= " << vectorString[1]
+	      << " is code= 0x" <<hex <<  m_canObjHandler << dec
+		  << " human readable code= " << humanReadableCode << std::endl;
 
 
 	if (strcmp(parameters.c_str(), "Unspecified") != 0)
@@ -242,7 +244,7 @@ bool PKCanScan::configureCanboard(const string name,const string parameters)
 	}
 
 	/** FD (flexible datarate) modules.
-	 * we need to contruct (a compplicated) bitrate string in this case, according to PEAK PCAN-Basic Documentation API manual p.82
+	 * we need to contruct (a complicated) bitrate string in this case, according to PEAK PCAN-Basic Documentation API manual p.82
 	 * two data rates, for nominal and data, can be defined.
 	 * all these parameters have to be passed
 	 *TPCANStatus tpcanStatus = CAN_InitializeFD(m_canObjHandler, m_baudRate);

--- a/CanInterfaceImplementations/pkcan/pkcan.cpp
+++ b/CanInterfaceImplementations/pkcan/pkcan.cpp
@@ -83,7 +83,7 @@ void PKCanScan::stopBus ()
 
 	// debug bus map
 	for (std::map<string, string>::iterator it = PKCanScan::m_busMap.begin(); it != PKCanScan::m_busMap.end(); ++it){
-		std::cout << " before " << it->first << " => " << it->second << std::endl;
+		std::cout << __FILE__ << " " << __LINE__ << " before " << it->first << " => " << it->second << std::endl;
 	}
 
 //#if 0
@@ -101,7 +101,7 @@ void PKCanScan::stopBus ()
 //#endif
 	// debug bus map
 	for (std::map<string, string>::iterator it = PKCanScan::m_busMap.begin(); it != PKCanScan::m_busMap.end(); ++it){
-		std::cout << " after " << it->first << " => " << it->second << std::endl;
+		std::cout << __FILE__ << " " << __LINE__ << " after " << it->first << " => " << it->second << std::endl;
 	}
 
 	MLOGPK(DBG,this) << "stopBus() finished";
@@ -204,6 +204,11 @@ bool PKCanScan::createBus(const string name ,const string parameters )
 		return false;
 	}
 
+	// debug bus map
+	for (std::map<string, string>::iterator it = PKCanScan::m_busMap.begin(); it != PKCanScan::m_busMap.end(); ++it){
+		std::cout << __FILE__ << " " << __LINE__ << " before " << it->first << " => " << it->second << std::endl;
+	}
+
 	// dont create a main thread for the same bus twice
 	bool skipMainThreadCreation = false;
 	std::map<string, string>::iterator it = PKCanScan::m_busMap.find( name );
@@ -213,6 +218,10 @@ bool PKCanScan::createBus(const string name ,const string parameters )
 	} else {
 		LOG(Log::WRN) << __FUNCTION__ << " bus exists already [" << name << ", " << parameters << "], not creating another main thread";
 		skipMainThreadCreation = true;
+	}
+	// debug bus map
+	for (std::map<string, string>::iterator it = PKCanScan::m_busMap.begin(); it != PKCanScan::m_busMap.end(); ++it){
+		std::cout << __FILE__ << " " << __LINE__ << " after " << it->first << " => " << it->second << std::endl;
 	}
 
 	if ( skipMainThreadCreation ){

--- a/CanInterfaceImplementations/pkcan/pkcan.cpp
+++ b/CanInterfaceImplementations/pkcan/pkcan.cpp
@@ -23,12 +23,15 @@
  * PEAK bridge integration for windows
  */
 
-#include "pkcan.h"
 #include <time.h>
 #include <string.h>
-#include "CanModuleUtils.h"
+#include <boost/thread/thread.hpp>
 
 #include <LogIt.h>
+
+#include "pkcan.h"
+#include "CanModuleUtils.h"
+
 
 /* static */ bool PKCanScan::s_logItRegisteredPk = false;
 /* static */ Log::LogComponentHandle PKCanScan::s_logItHandlePk = 0;

--- a/CanInterfaceImplementations/pkcan/pkcan.cpp
+++ b/CanInterfaceImplementations/pkcan/pkcan.cpp
@@ -280,7 +280,7 @@ bool PKCanScan::configureCanboard(const string name,const string parameters)
 	{
 		//numPar = sscanf_s(canpars, "%d %d %d %d %d %d", &parametersBaudRate, &parametersTseg1, &parametersTseg2, &parametersSjw, &parametersNoSamp, &parametersSyncmode);
 		//Get the can object handler
-		m_canObjHandler = getHandle(humanReadableCode /* vectorString[1].c_str() */ );
+		m_canObjHandler = getHandle( humanReadableCode.c_str() /* vectorString[1].c_str() */ );
 		//Process the baudRate if needed
 		if (m_CanParameters.m_iNumberOfDetectedParameters == 1)
 		{

--- a/CanInterfaceImplementations/pkcan/pkcan.cpp
+++ b/CanInterfaceImplementations/pkcan/pkcan.cpp
@@ -166,6 +166,9 @@ DWORD WINAPI PKCanScan::CanScanControlThread(LPVOID pCanScan)
  */
 bool PKCanScan::createBus(const string name ,const string parameters )
 {
+	m_busName = name;
+	m_busParameters = parameters;
+
 	// calling base class to get the instance from there
 	Log::LogComponentHandle myHandle;
 	LogItInstance* logItInstance = CCanAccess::getLogItInstance(); // actually calling instance method, not class

--- a/CanInterfaceImplementations/pkcan/pkcan.cpp
+++ b/CanInterfaceImplementations/pkcan/pkcan.cpp
@@ -75,9 +75,11 @@ void PKCanScan::stopBus ()
 
 	CAN_Uninitialize(m_canObjHandler);
 
-	// notify the thread that it should finish.
+
 	m_CanScanThreadRunEnableFlag = false;
-	MLOGPK(DBG,this) << " try joining threads...";
+	MLOGPK(DBG,this) << " try finishing thread...";
+
+	Sleep(2); // and wait a bit for the thread to die
 
 //#if 0
 	std::map<string, string>::iterator it = PKCanScan::m_busMap.find( m_busName );

--- a/CanInterfaceImplementations/pkcan/pkcan.cpp
+++ b/CanInterfaceImplementations/pkcan/pkcan.cpp
@@ -62,11 +62,6 @@ PKCanScan::PKCanScan():
 PKCanScan::~PKCanScan()
 {
 	stopBus();
-
-	// m_CanScanThreadRunEnableFlag = false;
-	////	CloseHandle(m_ReadEvent);
-
-	//CAN_Uninitialize(m_canObjHandler);
 }
 
 /**
@@ -74,23 +69,13 @@ PKCanScan::~PKCanScan()
  */
 void PKCanScan::stopBus ()
 {
-	// MLOGPK(DBG, this ) << __FUNCTION__ << " m_busName= " <<  m_busName ;
-	std::cout << __FILE__ << " " << __LINE__ << " " << __FUNCTION__ << " m_busName= " <<  m_busName << std::endl;
-
 	m_CanScanThreadRunEnableFlag = false;
-	MLOGPK(DBG,this) << " try finishing thread...";
-
-	MLOGPK(TRC, this) << "calling CAN_Uninitialize";
+	MLOGPK(TRC, this) << " try finishing thread...calling CAN_Uninitialize";
 	TPCANStatus tpcanStatus = CAN_Uninitialize(m_canObjHandler);
 	MLOGPK(TRC, this) << "CAN_Uninitialize returns " << (int) tpcanStatus;
 
 	{
 		peakReconnectMutex.lock();
-		// debug bus map
-		for (std::map<string, string>::iterator it = PKCanScan::m_busMap.begin(); it != PKCanScan::m_busMap.end(); ++it){
-			std::cout << __FILE__ << " " << __LINE__ << " before " << it->first << " => " << it->second << std::endl;
-		}
-
 		std::map<string, string>::iterator it = PKCanScan::m_busMap.find( m_busName );
 		if (it != PKCanScan::m_busMap.end()) {
 			m_idCanScanThread = 0;
@@ -100,15 +85,9 @@ void PKCanScan::stopBus ()
 		} else {
 			MLOGPK(DBG,this) << " bus " << m_busName << " does not exist";
 		}
-
-		// debug bus map
-		for (std::map<string, string>::iterator it = PKCanScan::m_busMap.begin(); it != PKCanScan::m_busMap.end(); ++it){
-			std::cout << __FILE__ << " " << __LINE__ << " after " << it->first << " => " << it->second << std::endl;
-		}
 		peakReconnectMutex.unlock();
 	}
 	Sleep(2); // and wait a bit for the thread to die
-
 	MLOGPK(DBG,this) << "stopBus() finished";
 }
 
@@ -202,9 +181,7 @@ bool PKCanScan::createBus(const string name ,const string parameters )
 	MLOGPK(DBG, this) << " name= " << name << " parameters= " << parameters << ", configuring CAN board";
 
 	m_sBusName = name; // maybe this can be cleaned up: we have m_busName already
-	//We configure the canboard
 	if ( !configureCanboard(name,parameters) ) {
-		//If we can't initialise the canboard, the thread is not started at all
 		MLOGPK( ERR, this ) << " name= " << name << " parameters= " << parameters << ", failed to configure CAN board";
 		return false;
 	}
@@ -212,11 +189,6 @@ bool PKCanScan::createBus(const string name ,const string parameters )
 	bool skipMainThreadCreation = false;
 	{
 		peakReconnectMutex.lock();
-		// debug bus map
-		for (std::map<string, string>::iterator it = PKCanScan::m_busMap.begin(); it != PKCanScan::m_busMap.end(); ++it){
-			std::cout << __FILE__ << " " << __LINE__ << " before " << it->first << " => " << it->second << std::endl;
-		}
-
 		// dont create a main thread for the same bus twice
 		std::map<string, string>::iterator it = PKCanScan::m_busMap.find( name );
 		if (it == PKCanScan::m_busMap.end()) {
@@ -225,10 +197,6 @@ bool PKCanScan::createBus(const string name ,const string parameters )
 		} else {
 			LOG(Log::WRN) << __FUNCTION__ << " bus exists already [" << name << ", " << parameters << "], not creating another main thread";
 			skipMainThreadCreation = true;
-		}
-		// debug bus map
-		for (std::map<string, string>::iterator it = PKCanScan::m_busMap.begin(); it != PKCanScan::m_busMap.end(); ++it){
-			std::cout << __FILE__ << " " << __LINE__ << " after " << it->first << " => " << it->second << std::endl;
 		}
 		peakReconnectMutex.unlock();
 	}

--- a/CanInterfaceImplementations/pkcan/pkcan.cpp
+++ b/CanInterfaceImplementations/pkcan/pkcan.cpp
@@ -70,12 +70,12 @@ PKCanScan::~PKCanScan()
  */
 void PKCanScan::stopBus ()
 {
-	MLOGPK(DBG, PKCanScan::s_logItHandlePk ) << __FUNCTION__ << " m_busName= " <<  m_busName ;
+	MLOGPK(DBG, this ) << __FUNCTION__ << " m_busName= " <<  m_busName ;
 	CAN_Uninitialize(m_canObjHandler);
 
 	// notify the thread that it should finish.
 	m_CanScanThreadRunEnableFlag = false;
-	MLOGPK(DBG,s_logItHandlePk) << " try joining threads...";
+	MLOGPK(DBG,this) << " try joining threads...";
 
 //#if 0
 	std::map<string, string>::iterator it = PKCanScan::m_busMap.find( m_busName );
@@ -87,10 +87,10 @@ void PKCanScan::stopBus ()
 		PKCanScan::m_busMap.erase ( it );
 		m_busName = "nobus";
 	} else {
-		MLOGPK(DBG,s_logItHandlePk) << " not joining threads... bus does not exist";
+		MLOGPK(DBG,this) << " not joining threads... bus does not exist";
 	}
 //#endif
-	MLOGPK(DBG,s_logItHandlePk) << "stopBus() finished";
+	MLOGPK(DBG,this) << "stopBus() finished";
 }
 
 

--- a/CanInterfaceImplementations/pkcan/pkcan.cpp
+++ b/CanInterfaceImplementations/pkcan/pkcan.cpp
@@ -239,7 +239,7 @@ bool PKCanScan::createBus(const string name ,const string parameters )
 	if ( skipMainThreadCreation ){
 		MLOGPK(TRC, this) << "Re-using main thread m_idCanScanThread= " << m_idCanScanThread;
 	}	else {
-		// Otherwise, we initialise the Scan thread
+		MLOGPK(TRC, this) << "creating  main thread m_idCanScanThread= " << m_idCanScanThread;
 		CAN_FilterMessages(m_canObjHandler,0,0x7FF,PCAN_MESSAGE_STANDARD);
 		m_hCanScanThread = CreateThread(NULL, 0, CanScanControlThread, this, 0, &m_idCanScanThread);
 		if ( NULL == m_hCanScanThread ) {
@@ -247,7 +247,6 @@ bool PKCanScan::createBus(const string name ,const string parameters )
 			return false;
 		}
 	}
-
 	return true;
 }
 

--- a/CanInterfaceImplementations/pkcan/pkcan.cpp
+++ b/CanInterfaceImplementations/pkcan/pkcan.cpp
@@ -335,10 +335,21 @@ bool PKCanScan::configureCanboard(const string name,const string parameters)
 
 	/**
 	 * fixed datarate modules (classical CAN), plug and play
+	 * we try 10 times until success, the OS is a bit slow
 	 */
 	MLOGPK(TRC, this) << "calling CAN_Initialize";
-	TPCANStatus tpcanStatus = CAN_Initialize(m_canObjHandler, m_baudRate );
-	MLOGPK(TRC, this) << "CAN_Initialize returns " << (int) tpcanStatus;
+	TPCANStatus tpcanStatus = 99;
+	int counter = 10;
+	while ( tpcanStatus != 0 && counter > 0 ){
+		tpcanStatus = CAN_Initialize(m_canObjHandler, m_baudRate );
+		MLOGPK(TRC, this) << "CAN_Initialize returns " << (int) tpcanStatus << " counter= " << counter;
+		if ( tpcanStatus == 0 ) {
+			MLOGPK(TRC, this) << "CAN_Initialize returns " << (int) tpcanStatus << " OK";
+			break;
+		}
+		Sleep( 1000 ); // 1000 ms
+		counter--;
+	}
 
 	/** fixed data rate, non plug-and-play
 	 * static TPCANStatus Initialize(

--- a/CanInterfaceImplementations/pkcan/pkcan.cpp
+++ b/CanInterfaceImplementations/pkcan/pkcan.cpp
@@ -348,8 +348,9 @@ bool PKCanScan::configureCanboard(const string name,const string parameters)
 			break;
 		}
 		Sleep( 1000 ); // 1000 ms
+		MLOGPK(TRC, this) << "try again... calling Can_Uninitialize " ;
 		tpcanStatus = CAN_Uninitialize( m_canObjHandler );
-		Sleep( 3000 ); // 3000 ms
+		Sleep( 1000 ); // 1000 ms
 		counter--;
 	}
 

--- a/CanInterfaceImplementations/pkcan/pkcan.cpp
+++ b/CanInterfaceImplementations/pkcan/pkcan.cpp
@@ -81,6 +81,11 @@ void PKCanScan::stopBus ()
 
 	Sleep(2); // and wait a bit for the thread to die
 
+	// debug bus map
+	for (std::map<string, string>::iterator it = PKCanScan::m_busMap.begin(); it != PKCanScan::m_busMap.end(); ++it){
+		std::cout << " before " << it->first << " => " << it->second << std::endl;
+	}
+
 //#if 0
 	std::map<string, string>::iterator it = PKCanScan::m_busMap.find( m_busName );
 	if (it != PKCanScan::m_busMap.end()) {
@@ -91,9 +96,14 @@ void PKCanScan::stopBus ()
 		PKCanScan::m_busMap.erase ( it );
 		m_busName = "nobus";
 	} else {
-		MLOGPK(DBG,this) << " not joining threads... bus does not exist";
+		MLOGPK(DBG,this) << " bus " << m_busName << " does not exist";
 	}
 //#endif
+	// debug bus map
+	for (std::map<string, string>::iterator it = PKCanScan::m_busMap.begin(); it != PKCanScan::m_busMap.end(); ++it){
+		std::cout << " after " << it->first << " => " << it->second << std::endl;
+	}
+
 	MLOGPK(DBG,this) << "stopBus() finished";
 }
 

--- a/CanInterfaceImplementations/pkcan/pkcan.cpp
+++ b/CanInterfaceImplementations/pkcan/pkcan.cpp
@@ -70,7 +70,9 @@ PKCanScan::~PKCanScan()
  */
 void PKCanScan::stopBus ()
 {
-	MLOGPK(DBG, this ) << __FUNCTION__ << " m_busName= " <<  m_busName ;
+	// MLOGPK(DBG, this ) << __FUNCTION__ << " m_busName= " <<  m_busName ;
+	std::cout << __FILE__ << " " << __LINE__ << " " << __FUNCTION__ << " m_busName= " <<  m_busName << std::endl;
+
 	CAN_Uninitialize(m_canObjHandler);
 
 	// notify the thread that it should finish.

--- a/CanInterfaceImplementations/pkcan/pkcan.cpp
+++ b/CanInterfaceImplementations/pkcan/pkcan.cpp
@@ -39,7 +39,7 @@
 
 #define MLOGPK(LEVEL,THIS) LOG(Log::LEVEL, PKCanScan::s_logItHandlePk) << __FUNCTION__ << " " << " peak bus= " << THIS->getBusName() << " "
 
-boost::mutex peakReconnectMutex; // protect m_busMap
+// boost::mutex peakReconnectMutex; // protect m_busMap
 
 
 bool  initLibarary =  false;
@@ -86,7 +86,7 @@ void PKCanScan::stopBus ()
 
 
 	{
-		peakReconnectMutex.lock();
+		// peakReconnectMutex.lock();
 		// debug bus map
 		for (std::map<string, string>::iterator it = PKCanScan::m_busMap.begin(); it != PKCanScan::m_busMap.end(); ++it){
 			std::cout << __FILE__ << " " << __LINE__ << " before " << it->first << " => " << it->second << std::endl;
@@ -109,7 +109,7 @@ void PKCanScan::stopBus ()
 		for (std::map<string, string>::iterator it = PKCanScan::m_busMap.begin(); it != PKCanScan::m_busMap.end(); ++it){
 			std::cout << __FILE__ << " " << __LINE__ << " after " << it->first << " => " << it->second << std::endl;
 		}
-		peakReconnectMutex.unlock();
+		// peakReconnectMutex.unlock();
 	}
 	Sleep(2); // and wait a bit for the thread to die
 
@@ -215,7 +215,7 @@ bool PKCanScan::createBus(const string name ,const string parameters )
 
 	bool skipMainThreadCreation = false;
 	{
-		peakReconnectMutex.lock();
+		// peakReconnectMutex.lock();
 		// debug bus map
 		for (std::map<string, string>::iterator it = PKCanScan::m_busMap.begin(); it != PKCanScan::m_busMap.end(); ++it){
 			std::cout << __FILE__ << " " << __LINE__ << " before " << it->first << " => " << it->second << std::endl;
@@ -234,7 +234,7 @@ bool PKCanScan::createBus(const string name ,const string parameters )
 		for (std::map<string, string>::iterator it = PKCanScan::m_busMap.begin(); it != PKCanScan::m_busMap.end(); ++it){
 			std::cout << __FILE__ << " " << __LINE__ << " after " << it->first << " => " << it->second << std::endl;
 		}
-		peakReconnectMutex.unlock();
+		// peakReconnectMutex.unlock();
 	}
 	if ( skipMainThreadCreation ){
 		MLOGPK(TRC, this) << "Re-using main thread m_idCanScanThread= " << m_idCanScanThread;

--- a/CanInterfaceImplementations/pkcan/pkcan.cpp
+++ b/CanInterfaceImplementations/pkcan/pkcan.cpp
@@ -80,6 +80,8 @@ void PKCanScan::stopBus ()
 //#if 0
 	std::map<string, string>::iterator it = PKCanScan::m_busMap.find( m_busName );
 	if (it != PKCanScan::m_busMap.end()) {
+
+		// windows does not have pthread_join
 		pthread_join( m_hCanScanThread, 0 );
 		m_idCanScanThread = 0;
 		PKCanScan::m_busMap.erase ( it );
@@ -100,7 +102,7 @@ DWORD WINAPI PKCanScan::CanScanControlThread(LPVOID pCanScan)
 	PKCanScan *pkCanScanPointer = reinterpret_cast<PKCanScan *>(pCanScan);
 	TPCANHandle tpcanHandler = pkCanScanPointer->m_canObjHandler;
 	MLOGPK(DBG,pkCanScanPointer) << "CanScanControlThread Started. m_CanScanThreadShutdownFlag = [" << pkCanScanPointer->m_CanScanThreadRunEnableFlag <<"]";
-	m_CanScanThreadRunEnableFlag = true;
+	pkCanScanPointer->m_CanScanThreadRunEnableFlag = true;
 	while ( pkCanScanPointer->m_CanScanThreadRunEnableFlag ) {
 		TPCANMsg tpcanMessage;
 		TPCANTimestamp tpcanTimestamp;

--- a/CanInterfaceImplementations/pkcan/pkcan.cpp
+++ b/CanInterfaceImplementations/pkcan/pkcan.cpp
@@ -68,15 +68,15 @@ PKCanScan::~PKCanScan()
 /**
  * notify the main thread to finish and delete the bus from the map of connections
  */
-bool PKCanScan::stopBus ()
+void PKCanScan::stopBus ()
 {
-	MLOGPK(DBG,pkCanScanPointer) << __FUNCTION__ << " m_busName= " <<  m_busName << " m_canObjHandler= 0x"
+	MLOGPK(DBG,s_logItHandlePk) << __FUNCTION__ << " m_busName= " <<  m_busName << " m_canObjHandler= 0x"
 			<< hex << m_canObjHandler << dec;
 	CAN_Uninitialize(m_canObjHandler);
 
 	// notify the thread that it should finish.
 	m_CanScanThreadRunEnableFlag = false;
-	MLOGPK(DBG,pkCanScanPointer) << " try joining threads...";
+	MLOGPK(DBG,s_logItHandlePk) << " try joining threads...";
 
 //#if 0
 	std::map<string, string>::iterator it = PKCanScan::m_busMap.find( m_busName );
@@ -86,11 +86,10 @@ bool PKCanScan::stopBus ()
 		PKCanScan::m_busMap.erase ( it );
 		m_busName = "nobus";
 	} else {
-		MLOGPK(DBG,pkCanScanPointer) << " not joining threads... bus does not exist";
+		MLOGPK(DBG,s_logItHandlePk) << " not joining threads... bus does not exist";
 	}
 //#endif
-	MLOGPK(DBG,pkCanScanPointer) << "stopBus() finished";
-	return true;
+	MLOGPK(DBG,s_logItHandlePk) << "stopBus() finished";
 }
 
 

--- a/CanInterfaceImplementations/pkcan/pkcan.cpp
+++ b/CanInterfaceImplementations/pkcan/pkcan.cpp
@@ -39,7 +39,7 @@
 
 #define MLOGPK(LEVEL,THIS) LOG(Log::LEVEL, PKCanScan::s_logItHandlePk) << __FUNCTION__ << " " << " peak bus= " << THIS->getBusName() << " "
 
-// boost::mutex peakReconnectMutex; // protect m_busMap
+boost::mutex peakReconnectMutex; // protect m_busMap
 
 
 bool  initLibarary =  false;
@@ -84,9 +84,8 @@ void PKCanScan::stopBus ()
 	TPCANStatus tpcanStatus = CAN_Uninitialize(m_canObjHandler);
 	MLOGPK(TRC, this) << "CAN_Uninitialize returns " << (int) tpcanStatus;
 
-
 	{
-		// peakReconnectMutex.lock();
+		peakReconnectMutex.lock();
 		// debug bus map
 		for (std::map<string, string>::iterator it = PKCanScan::m_busMap.begin(); it != PKCanScan::m_busMap.end(); ++it){
 			std::cout << __FILE__ << " " << __LINE__ << " before " << it->first << " => " << it->second << std::endl;
@@ -94,9 +93,6 @@ void PKCanScan::stopBus ()
 
 		std::map<string, string>::iterator it = PKCanScan::m_busMap.find( m_busName );
 		if (it != PKCanScan::m_busMap.end()) {
-
-			// windows does not have pthread_join
-			//pthread_join( m_hCanScanThread, 0 );
 			m_idCanScanThread = 0;
 			PKCanScan::m_busMap.erase ( it );
 			m_busName = "nobus";
@@ -109,7 +105,7 @@ void PKCanScan::stopBus ()
 		for (std::map<string, string>::iterator it = PKCanScan::m_busMap.begin(); it != PKCanScan::m_busMap.end(); ++it){
 			std::cout << __FILE__ << " " << __LINE__ << " after " << it->first << " => " << it->second << std::endl;
 		}
-		// peakReconnectMutex.unlock();
+		peakReconnectMutex.unlock();
 	}
 	Sleep(2); // and wait a bit for the thread to die
 
@@ -215,7 +211,7 @@ bool PKCanScan::createBus(const string name ,const string parameters )
 
 	bool skipMainThreadCreation = false;
 	{
-		// peakReconnectMutex.lock();
+		peakReconnectMutex.lock();
 		// debug bus map
 		for (std::map<string, string>::iterator it = PKCanScan::m_busMap.begin(); it != PKCanScan::m_busMap.end(); ++it){
 			std::cout << __FILE__ << " " << __LINE__ << " before " << it->first << " => " << it->second << std::endl;
@@ -234,7 +230,7 @@ bool PKCanScan::createBus(const string name ,const string parameters )
 		for (std::map<string, string>::iterator it = PKCanScan::m_busMap.begin(); it != PKCanScan::m_busMap.end(); ++it){
 			std::cout << __FILE__ << " " << __LINE__ << " after " << it->first << " => " << it->second << std::endl;
 		}
-		// peakReconnectMutex.unlock();
+		peakReconnectMutex.unlock();
 	}
 	if ( skipMainThreadCreation ){
 		MLOGPK(TRC, this) << "Re-using main thread m_idCanScanThread= " << m_idCanScanThread;

--- a/CanInterfaceImplementations/pkcan/pkcan.h
+++ b/CanInterfaceImplementations/pkcan/pkcan.h
@@ -76,6 +76,8 @@ private:
 	bool m_CanScanThreadRunEnableFlag;
 	//Current baud rate
 	unsigned int m_baudRate;
+	string m_busName;
+	string m_busParameters;
 
 	//Instance of the can handle
    	TPCANHandle	m_canObjHandler;

--- a/CanInterfaceImplementations/pkcan/pkcan.h
+++ b/CanInterfaceImplementations/pkcan/pkcan.h
@@ -80,7 +80,7 @@ private:
 	//Instance of the can handle
    	TPCANHandle	m_canObjHandler;
 	bool configureCanboard(const string name,const string parameters);
-	bool stopBus ( void );
+	void stopBus ( void );
 
 	HANDLE      m_hCanScanThread;
 //	HANDLE		m_ReadEvent;

--- a/CanInterfaceImplementations/pkcan/pkcan.h
+++ b/CanInterfaceImplementations/pkcan/pkcan.h
@@ -61,6 +61,7 @@ public:
 
 	static Log::LogComponentHandle s_logItHandlePk;
 	static bool s_logItRegisteredPk;
+	static std::map<string, string> m_busMap; // {name, parameters}
 
 private:
 	TPCANHandle getHandle(const char *name);
@@ -79,6 +80,7 @@ private:
 	//Instance of the can handle
    	TPCANHandle	m_canObjHandler;
 	bool configureCanboard(const string name,const string parameters);
+	bool stopBus ( void );
 
 	HANDLE      m_hCanScanThread;
 //	HANDLE		m_ReadEvent;

--- a/CanInterfaceImplementations/pkcan/pkcan.h
+++ b/CanInterfaceImplementations/pkcan/pkcan.h
@@ -72,7 +72,7 @@ private:
 	//Instance of Can Statistics
 	CanStatistics m_statistics;
 	TPCANStatus m_busStatus;
-	bool m_CanScanThreadShutdownFlag;
+	bool m_CanScanThreadRunEnableFlag;
 	//Current baud rate
 	unsigned int m_baudRate;
 

--- a/CanInterfaceImplementations/sockcan/SockCanScan.cpp
+++ b/CanInterfaceImplementations/sockcan/SockCanScan.cpp
@@ -688,18 +688,22 @@ bool CSockCanScan::stopBus ()
 		std::map<string, string>::iterator it0 = CSockCanScan::m_busMap.begin();
 		int ii = 0;
 		while ( it0 != CSockCanScan::m_busMap.end() ) {
-			LOG(Log::TRC) << "OPCUA-1536 before " << ii << " " << string(it0->first) << " " << string(it0->second) ;
+			MLOGSOCK(DBG,this) << "OPCUA-1536 before " << ii << " " << string(it0->first) << " " << string(it0->second) ;
 			it0++;ii++;
 		}
 	}
 
 
-	pthread_join( m_hCanScanThread, 0 );
-	m_idCanScanThread = 0;
+//	pthread_join( m_hCanScanThread, 0 );
+//	m_idCanScanThread = 0;
 	std::map<string, string>::iterator it = CSockCanScan::m_busMap.find( m_busName );
 	if (it != CSockCanScan::m_busMap.end()) {
+		pthread_join( m_hCanScanThread, 0 );
+		m_idCanScanThread = 0;
 		CSockCanScan::m_busMap.erase ( it );
 		m_busName = "nobus";
+	} else {
+		MLOGSOCK(DBG,this) << " not joining threads... bus does not exist";
 	}
 	MLOGSOCK(DBG,this) << "stopBus() finished";
 	return true;

--- a/CanInterfaceImplementations/sockcan/SockCanScan.cpp
+++ b/CanInterfaceImplementations/sockcan/SockCanScan.cpp
@@ -678,9 +678,21 @@ void CSockCanScan::sendErrorMessage(const char *mess)
  */
 bool CSockCanScan::stopBus ()
 {
+	MLOGSOCK(DBG,this) << __FUNCTION__ << " m_busName= " <<  m_busName;
 	// notify the thread that it should finish.
 	m_CanScanThreadRunEnableFlag = false;
 	MLOGSOCK(DBG,this) << " joining threads... m_idCanScanThread= " << m_idCanScanThread;
+
+	// check bus map contents OPCUA-1536
+	{
+		std::map<string, string>::iterator it0 = CSockCanScan::m_busMap.begin();
+		int ii = 0;
+		while ( it0 != CSockCanScan::m_busMap.end() ) {
+			LOG(Log::TRC) << "OPCUA-1536 before " << ii << " " << string(it0->first) << " " << string(it0->second) ;
+			it0++;ii++;
+		}
+	}
+
 
 	pthread_join( m_hCanScanThread, 0 );
 	m_idCanScanThread = 0;

--- a/CanInterfaceImplementations/sockcan/SockCanScan.cpp
+++ b/CanInterfaceImplementations/sockcan/SockCanScan.cpp
@@ -45,9 +45,7 @@
 #include <LogIt.h>
 using namespace std;
 
-// /* static */ std::map<string, string> CSockCanScan::m_busMap = {{"dummy_name", "dummy_parameters"}};
 /* static */ std::map<string, string> CSockCanScan::m_busMap;
-
 /* static */ Log::LogComponentHandle CSockCanScan::st_logItHandleSock;
 
 #define MLOGSOCK(LEVEL,THIS) LOG(Log::LEVEL, CSockCanScan::st_logItHandleSock) << __FUNCTION__ << " sock bus= " << THIS->getBusName() << " "

--- a/CanInterfaceImplementations/sockcan/SockCanScan.cpp
+++ b/CanInterfaceImplementations/sockcan/SockCanScan.cpp
@@ -547,6 +547,7 @@ bool CSockCanScan::createBus(const string name, const string parameters)
 	std::map<string, string>::iterator it = CSockCanScan::m_busMap.find( name );
 	if (it == CSockCanScan::m_busMap.end()) {
 		CSockCanScan::m_busMap.insert ( std::pair<string, string>(name, parameters) );
+		m_busName = name;
 	} else {
 		LOG(Log::WRN) << __FUNCTION__ << " OPCUA-1536 bus exists already [" << name << ", " << parameters << "], not creating another main thread";
 		skip = true;
@@ -700,6 +701,35 @@ bool CSockCanScan::stopBus ()
 	pthread_join( m_hCanScanThread, 0 );
 	m_idCanScanThread = 0;
 	MLOGSOCK(DBG,this) << "stopBus() finished";
+
+	// check bus map contents OPCUA-1536
+	{
+		std::map<string, string>::iterator it0 = CSockCanScan::m_busMap.begin();
+		int ii = 0;
+		while ( it0 != CSockCanScan::m_busMap.end() ) {
+			LOG(Log::TRC) << "OPCUA-1536 before " << ii << " " << string(it0->first) << " " << string(it0->second) ;
+			it0++;ii++;
+		}
+	}
+
+	std::map<string, string>::iterator it = CSockCanScan::m_busMap.find( m_busName );
+	if (it != CSockCanScan::m_busMap.end()) {
+		CSockCanScan::m_busMap.erase ( it );
+		m_busName = "nobus";
+	}
+
+	// check bus map contents OPCUA-1536
+	{
+		std::map<string, string>::iterator it0 = CSockCanScan::m_busMap.begin();
+		int ii = 0;
+		while ( it0 != CSockCanScan::m_busMap.end() ) {
+			LOG(Log::TRC) << "OPCUA-1536 before " << ii << " " << string(it0->first) << " " << string(it0->second) ;
+			it0++;ii++;
+		}
+	}
+
+
+
 	return true;
 }
 

--- a/CanInterfaceImplementations/sockcan/SockCanScan.cpp
+++ b/CanInterfaceImplementations/sockcan/SockCanScan.cpp
@@ -690,7 +690,7 @@ bool CSockCanScan::stopBus ()
 	MLOGSOCK(DBG,this) << " try joining threads...";
 
 	{
-		sockReconnectMutexectMutex.lock();
+		sockReconnectMutex.lock();
 		std::map<string, string>::iterator it = CSockCanScan::m_busMap.find( m_busName );
 		if (it != CSockCanScan::m_busMap.end()) {
 			pthread_join( m_hCanScanThread, 0 );
@@ -700,7 +700,7 @@ bool CSockCanScan::stopBus ()
 		} else {
 			MLOGSOCK(DBG,this) << " not joining threads... bus does not exist";
 		}
-		sockReconnectMutexectMutex.unlock();
+		sockReconnectMutex.unlock();
 	}
 	MLOGSOCK(DBG,this) << "stopBus() finished";
 	return true;

--- a/CanInterfaceImplementations/sockcan/SockCanScan.cpp
+++ b/CanInterfaceImplementations/sockcan/SockCanScan.cpp
@@ -570,7 +570,6 @@ bool CSockCanScan::createBus(const string name, const string parameters)
 	}
 	if ( skipMainThreadCreation ){
 		MLOGSOCK(TRC,this) << "Re-using main thread m_idCanScanThread= " << m_idCanScanThread;
-
 	} else {
 		MLOGSOCK(TRC,this) << "Created bus with parameters [" << parameters << "], starting main loop";
 		m_idCanScanThread =	pthread_create(&m_hCanScanThread,NULL,&CanScanControlThread, (void *)this);

--- a/CanInterfaceImplementations/sockcan/SockCanScan.cpp
+++ b/CanInterfaceImplementations/sockcan/SockCanScan.cpp
@@ -587,11 +587,12 @@ bool CSockCanScan::createBus(const string name, const string parameters)
 	}
 	if ( skip ){
 		// m_idCanScanThread = 0; // reuse thread, don't invalidate
-		MLOGSOCK(TRC,this) << "Re-using bus with parameters [" << parameters << "], re-use main loop as well";
+		MLOGSOCK(TRC,this) << "Re-using main thread m_idCanScanThread= " << m_idCanScanThread;
 
 	} else {
 		MLOGSOCK(TRC,this) << "Created bus with parameters [" << parameters << "], starting main loop";
 		m_idCanScanThread =	pthread_create(&m_hCanScanThread,NULL,&CanScanControlThread, (void *)this);
+		MLOGSOCK(TRC,this) << "created main thread m_idCanScanThread= " << m_idCanScanThread;
 	}
 	return( true );
 }
@@ -694,9 +695,11 @@ bool CSockCanScan::stopBus ()
 {
 	// notify the thread that it should finish.
 	m_CanScanThreadShutdownFlag = false;
-	MLOGSOCK(DBG,this) << " joining threads...  m_hCanScanThread= " << m_hCanScanThread;
+	MLOGSOCK(DBG,this) << " joining threads... m_idCanScanThread= " << m_idCanScanThread;
+
 	pthread_join( m_hCanScanThread, 0 );
-	MLOGSOCK(DBG,this) << "stopBus() finished... m_hCanScanThread= " << m_hCanScanThread";
+	m_idCanScanThread = 0;
+	MLOGSOCK(DBG,this) << "stopBus() finished";
 	return true;
 }
 

--- a/CanInterfaceImplementations/sockcan/SockCanScan.cpp
+++ b/CanInterfaceImplementations/sockcan/SockCanScan.cpp
@@ -43,7 +43,7 @@
 #include <CanModuleUtils.h>
 
 #include <LogIt.h>
-using namespace std;
+// using namespace std;
 
 /* static */ std::map<string, string> CSockCanScan::m_busMap;
 /* static */ Log::LogComponentHandle CSockCanScan::st_logItHandleSock;
@@ -51,10 +51,10 @@ using namespace std;
 #define MLOGSOCK(LEVEL,THIS) LOG(Log::LEVEL, CSockCanScan::st_logItHandleSock) << __FUNCTION__ << " sock bus= " << THIS->getBusName() << " "
 
 
-//! The macro below is applicable only to this translation unit
-//#define MLOG(LEVEL,THIS) LOG(Log::LEVEL) << THIS->m_channelName << " "
-
-//This function creates an instance of this class and returns it. It will be loaded trough the dll to access the rest of the code.
+/**
+ * This function creates an instance of this class and returns it.
+ * It will be loaded trough the dll to access the rest of the code.
+ */
 extern "C" CCanAccess *getCanBusAccess()
 {
 	CCanAccess *cc = new CSockCanScan();
@@ -66,7 +66,8 @@ CSockCanScan::CSockCanScan() :
 			m_sock(0),
 			m_hCanScanThread(0),
 			m_idCanScanThread(0),
-			m_errorCode(-1)
+			m_errorCode(-1),
+			m_busName("nobus")
 {
 	m_statistics.beginNewRun();
 }
@@ -681,21 +682,8 @@ bool CSockCanScan::stopBus ()
 	MLOGSOCK(DBG,this) << __FUNCTION__ << " m_busName= " <<  m_busName;
 	// notify the thread that it should finish.
 	m_CanScanThreadRunEnableFlag = false;
-	MLOGSOCK(DBG,this) << " joining threads... m_idCanScanThread= " << m_idCanScanThread;
+	MLOGSOCK(DBG,this) << " try joining threads...";
 
-	// check bus map contents OPCUA-1536
-	{
-		std::map<string, string>::iterator it0 = CSockCanScan::m_busMap.begin();
-		int ii = 0;
-		while ( it0 != CSockCanScan::m_busMap.end() ) {
-			MLOGSOCK(DBG,this) << "OPCUA-1536 before " << ii << " " << string(it0->first) << " " << string(it0->second) ;
-			it0++;ii++;
-		}
-	}
-
-
-//	pthread_join( m_hCanScanThread, 0 );
-//	m_idCanScanThread = 0;
 	std::map<string, string>::iterator it = CSockCanScan::m_busMap.find( m_busName );
 	if (it != CSockCanScan::m_busMap.end()) {
 		pthread_join( m_hCanScanThread, 0 );

--- a/CanInterfaceImplementations/sockcan/SockCanScan.cpp
+++ b/CanInterfaceImplementations/sockcan/SockCanScan.cpp
@@ -43,7 +43,6 @@
 #include <CanModuleUtils.h>
 
 #include <LogIt.h>
-// using namespace std;
 
 /* static */ std::map<string, string> CSockCanScan::m_busMap;
 /* static */ Log::LogComponentHandle CSockCanScan::st_logItHandleSock;

--- a/CanInterfaceImplementations/sockcan/SockCanScan.h
+++ b/CanInterfaceImplementations/sockcan/SockCanScan.h
@@ -27,11 +27,15 @@
 #include <pthread.h>
 #include <unistd.h>
 #include <string>
-#include "CCanAccess.h"
-#include "CanStatistics.h"
 #include <sys/socket.h>
 #include <linux/can.h>
-#include "libsocketcan.h"
+#
+#include <boost/thread/thread.hpp>
+
+
+#include "CCanAccess.h"
+#include "CanStatistics.h"
+include "libsocketcan.h"
 
 /*
  * This is an implementation of the abstract class CCanAccess. It serves as a can bus access layer that will communicate with socket can (Linux only)

--- a/CanInterfaceImplementations/sockcan/SockCanScan.h
+++ b/CanInterfaceImplementations/sockcan/SockCanScan.h
@@ -78,17 +78,14 @@ public:
 	static std::map<string, string> m_busMap;
 
 private:
+	volatile bool m_CanScanThreadRunEnableFlag; //Flag for running/shutting down the CanScan thread
 
-	//Flag for running/shutting down the CanScan thread
-	volatile bool m_CanScanThreadRunEnableFlag;
-	//Socket handler
-	int m_sock;
-	//Instance of Can Statistics
-	CanStatistics m_statistics;
-	//Handle for the CAN update scan manager thread.
-	pthread_t m_hCanScanThread;
-	//Thread ID for the CAN update scan manager thread.
-	int m_idCanScanThread;
+	int m_sock;                 //Socket handler
+	CanStatistics m_statistics;// Instance of Can Statistics
+	pthread_t m_hCanScanThread;	// Handle for the CAN update scan manager thread.
+	int m_idCanScanThread; // Thread ID for the CAN update scan manager thread.
+	int m_errorCode; // As up-to-date as possible state of the interface.
+	std::string m_channelName;
 	std::string m_busName;
 
 	static Log::LogComponentHandle st_logItHandleSock;
@@ -117,11 +114,7 @@ private:
 	//The main control thread function for the CAN update scan manager.
 	static void* CanScanControlThread(void *);
 
-	//Channel name
-	std::string m_channelName;
 
-	//! As up-to-date as possible state of the interface.
-	int m_errorCode;
 };
 
 

--- a/CanInterfaceImplementations/sockcan/SockCanScan.h
+++ b/CanInterfaceImplementations/sockcan/SockCanScan.h
@@ -89,6 +89,7 @@ private:
 	pthread_t m_hCanScanThread;
 	//Thread ID for the CAN update scan manager thread.
 	int m_idCanScanThread;
+	std::string m_busName;
 
 	static Log::LogComponentHandle st_logItHandleSock;
 

--- a/CanInterfaceImplementations/sockcan/SockCanScan.h
+++ b/CanInterfaceImplementations/sockcan/SockCanScan.h
@@ -29,13 +29,12 @@
 #include <string>
 #include <sys/socket.h>
 #include <linux/can.h>
-#
 #include <boost/thread/thread.hpp>
 
 
 #include "CCanAccess.h"
 #include "CanStatistics.h"
-include "libsocketcan.h"
+#include "libsocketcan.h"
 
 /*
  * This is an implementation of the abstract class CCanAccess. It serves as a can bus access layer that will communicate with socket can (Linux only)

--- a/CanInterfaceImplementations/sockcan/SockCanScan.h
+++ b/CanInterfaceImplementations/sockcan/SockCanScan.h
@@ -79,8 +79,8 @@ public:
 
 private:
 
-	//Flag for shutting down the CanScan thread
-	volatile bool m_CanScanThreadShutdownFlag;
+	//Flag for running/shutting down the CanScan thread
+	volatile bool m_CanScanThreadRunEnableFlag;
 	//Socket handler
 	int m_sock;
 	//Instance of Can Statistics

--- a/CanInterfaceImplementations/sockcan/SockCanScan.h
+++ b/CanInterfaceImplementations/sockcan/SockCanScan.h
@@ -75,7 +75,7 @@ public:
 		}
 		return(f);
 	}
-	static std::map<string, string> m_busMap;
+	static std::map<string, string> m_busMap; // {name, parameters}
 
 private:
 	volatile bool m_CanScanThreadRunEnableFlag; //Flag for running/shutting down the CanScan thread

--- a/CanLibLoader/src/CanLibLoader.cpp
+++ b/CanLibLoader/src/CanLibLoader.cpp
@@ -58,7 +58,7 @@ namespace CanModule
 		delete cInter; // dtor calls stopBus()
 		{
 			struct timespec tim, tim2;
-			tim.tv_sec = 2;
+			tim.tv_sec = 3;
 			tim.tv_nsec = 0;
 			if(nanosleep(&tim , &tim2) < 0 ) {
 				LOG(Log::ERR, lh ) << __FUNCTION__ << " Waiting failed (nanosleep)";

--- a/CanLibLoader/src/CanLibLoader.cpp
+++ b/CanLibLoader/src/CanLibLoader.cpp
@@ -53,20 +53,19 @@ namespace CanModule
 	}
 
 	void CanLibLoader::closeCanBus(CCanAccess *cInter) {
-		LOG(Log::DBG, lh ) << __FUNCTION__<< " OPCUA-1536 Canbus name to be deleted: " << cInter->getBusName();
-		//	m_openCanAccessMap.erase(cInter->getBusName().c_str());
-		delete cInter;
+		LOG(Log::DBG, lh ) << __FUNCTION__<< " Canbus name to be deleted: " << cInter->getBusName();
+		delete cInter; // dtor calls stopBus()
 	}
 
 	CCanAccess* CanLibLoader::openCanBus(string name, string parameters) {
-		LOG(Log::DBG, lh ) << __FUNCTION__ << " OPCUA-1536 Creating CCanAccess: name= " << name << " parameters= " << parameters;
+		LOG(Log::DBG, lh ) << __FUNCTION__ << " Creating CCanAccess: name= " << name << " parameters= " << parameters;
 		CCanAccess *tcca = createCanAccess();
 
 		if ( !tcca ){
-			LOG(Log::ERR, lh ) << __FUNCTION__ << " OPCUA-1536 failed to create CCanAccess name= " << name << " parameters= " << parameters;
+			LOG(Log::ERR, lh ) << __FUNCTION__ << " failed to create CCanAccess name= " << name << " parameters= " << parameters;
 			exit(-1);
 		} else {
-			LOG(Log::DBG, lh ) << __FUNCTION__ << " OPCUA-1536 created CCanAccess name= " << name << " parameters= " << parameters;
+			LOG(Log::DBG, lh ) << __FUNCTION__ << " created CCanAccess name= " << name << " parameters= " << parameters;
 		}
 
 		//The Logit instance of the executable is handled to the DLL at this point, so the instance is shared.

--- a/CanLibLoader/src/CanLibLoader.cpp
+++ b/CanLibLoader/src/CanLibLoader.cpp
@@ -53,17 +53,8 @@ namespace CanModule
 	}
 
 	void CanLibLoader::closeCanBus(CCanAccess *cInter) {
-		LOG(Log::DBG, lh ) << __FUNCTION__<< " Canbus name to be deleted: " << cInter->getBusName()
-				<< " imposing a delay of 3 seconds before continuing";
+		LOG(Log::DBG, lh ) << __FUNCTION__<< " Canbus name to be deleted: " << cInter->getBusName();
 		delete cInter; // dtor calls stopBus()
-		{
-			struct timespec tim, tim2;
-			tim.tv_sec = 3;
-			tim.tv_nsec = 0;
-			if(nanosleep(&tim , &tim2) < 0 ) {
-				LOG(Log::ERR, lh ) << __FUNCTION__ << " Waiting failed (nanosleep)";
-			}
-		}
 	}
 
 	CCanAccess* CanLibLoader::openCanBus(string name, string parameters) {

--- a/CanLibLoader/src/CanLibLoader.cpp
+++ b/CanLibLoader/src/CanLibLoader.cpp
@@ -61,7 +61,7 @@ namespace CanModule
 			tim.tv_sec = 2;
 			tim.tv_nsec = 0;
 			if(nanosleep(&tim , &tim2) < 0 ) {
-				MLOGSOCK(ERR,p_sockCanScan) << "Waiting failed (nanosleep)";
+				LOG(Log::ERR, lh ) << __FUNCTION__ << " Waiting failed (nanosleep)";
 			}
 		}
 	}

--- a/CanLibLoader/src/CanLibLoader.cpp
+++ b/CanLibLoader/src/CanLibLoader.cpp
@@ -61,8 +61,7 @@ namespace CanModule
 			tim.tv_sec = 2;
 			tim.tv_nsec = 0;
 			if(nanosleep(&tim , &tim2) < 0 ) {
-				MLOGSOCK(ERR,p_sockCanScan) << "Waiting 1s failed (nanosleep)"
-						<< " tid= " << _tid;
+				MLOGSOCK(ERR,p_sockCanScan) << "Waiting failed (nanosleep)";
 			}
 		}
 	}

--- a/CanLibLoader/src/CanLibLoader.cpp
+++ b/CanLibLoader/src/CanLibLoader.cpp
@@ -53,8 +53,18 @@ namespace CanModule
 	}
 
 	void CanLibLoader::closeCanBus(CCanAccess *cInter) {
-		LOG(Log::DBG, lh ) << __FUNCTION__<< " Canbus name to be deleted: " << cInter->getBusName();
+		LOG(Log::DBG, lh ) << __FUNCTION__<< " Canbus name to be deleted: " << cInter->getBusName()
+				<< " imposing a delay of 3 seconds before continuing";
 		delete cInter; // dtor calls stopBus()
+		{
+			struct timespec tim, tim2;
+			tim.tv_sec = 2;
+			tim.tv_nsec = 0;
+			if(nanosleep(&tim , &tim2) < 0 ) {
+				MLOGSOCK(ERR,p_sockCanScan) << "Waiting 1s failed (nanosleep)"
+						<< " tid= " << _tid;
+			}
+		}
 	}
 
 	CCanAccess* CanLibLoader::openCanBus(string name, string parameters) {

--- a/Documentation/sphinx-source/connection.rst
+++ b/Documentation/sphinx-source/connection.rst
@@ -65,8 +65,10 @@ systec
 
 - A power loss or a connection loss will trigger a reconnection. For linux, where socketcan is used,
 this works in the same way as for peak. Connections are managed in a global map. 
-- A software close/open is fully supported and works under cc7 without limitations.
-- For windows the reconnection is NOT WORKING, and it is not clear if it can actually
+- A software close/open is fully supported and works under cc7 and also windows without limitations. 
+If the sequence is too fast (for the environment..) some messages will be lost, but the 
+module recuperates correctly in the following.  
+- For windows the hardware reconnection is NOT WORKING, and it is not clear if it can actually
 be achieved within CanModule. It seems that a library reload is needed to make the module work again.
 This feature is therefore DROPPED for now, since also no strong user request for "systec reconnection
 under windows" is presently stated. I tried, using the systec API@windows as documented, but did not manage.

--- a/Documentation/sphinx-source/connection.rst
+++ b/Documentation/sphinx-source/connection.rst
@@ -6,14 +6,15 @@ CanModule tries to recuperate lost connections automatically, but presently ther
 to interrogate CanModule on the status of it's connected modules. This might be added later, though.
 
 anagate
--------
+=======
+
 The anagate modules are easily and uniquely identified by their IP address, also several modules 
 per CanModule instance are straightforward. An anagate bridge can be disconnected in 4 ways:
 
-* power loss - power back
-* network interruption
-* firmware reset by software through the API
-* software close CAN bus (followed by sw open)
+1. power loss - power back
+2. network interruption
+3. firmware reset by software through the API
+4. software close CAN bus (followed by sw open)
 
 the firmware reset is NOT implemented in the CanModule, but a module can be remotely accessed and 
 firmware reset using the vendor API, through code like: 
@@ -23,8 +24,7 @@ firmware reset using the vendor API, through code like:
 	AnaInt32 timeout = 12000; // 12secs
 	AnaInt32 anaRet = CANRestart( "192.168.1.10", timeout );
 
-
-In all the first 3 cases CanModule detects a failure to send a message on a port, and tries to reconnect 
+In the cases 1-3 CanModule detects a failure to send a message on a port, and tries to reconnect 
 all ports of that module. Sending messages are buffered for ~20secs, and the reconnection 
 takes at least ~20sec, so it takes ~1 minute to reestablish communication. All received CAN frames 
 are lost, and not all sent frames are guaranteed, therefore some care has to be taken when the
@@ -37,18 +37,22 @@ The whole reconnection can take up to 60 secs until all buffers are cleared, so 
 
 The 4th case, software close/open, leads to a deallocation of the connection object, followed by a newly
 created connection. These objects are recorded in a (anagate-global) connection map. The library 
-load object (see standard API) can also be deallocated and recreated.
+load object (see standard API) can also be deallocated and recreated, but it may also be reused.
  
-- the Anagate modules tend to firmware-crash if too many CAN bus close/open are executed too quickly, 
-making a full power-cycle of the module necessary. A delay of 7 seconds between a close and 
-a (re-)open per module is therefore imposed by CanModule to avoid "firmware-crashing" a module. This crash
-occurs independently from the connection timeout. A bigger delay is recommended if it can be afforded:
-lab-tests show a 7sec delay still crashes after 30 consecutive reconnects. These crashes can also
-be related to networking problems but they are difficult to investigate.
+WARNING: the Anagate modules tend to firmware-crash if too many CAN bus software close/open are 
+executed too quickly, making a full power-cycle of the module necessary. A delay of 7 seconds 
+between a close and a (re-)open per module is therefore imposed by CanModule to avoid 
+"firmware-crashing" of the anagate module. This crash occurs independently from the connection 
+timeout. 
+
+A bigger delay is recommended if it can be afforded: lab-tests show a 7sec delay still crashes 
+after 30 consecutive reconnects. These crashes can also be related to networking problems but 
+they are difficult to fix.
 
 
 peak
-----
+====
+
 - The module is receiving power through the USB port, if this connection is lost we need to reconnect.
 Reconnection works for both normal (fixed) and flexible datarate (FD) modules under linux, as 
 socketcan is used. For windows only normal datarate (fixed) are supported, and the reconnection 
@@ -57,9 +61,10 @@ also works for them.
 - A software close/open is fully supported and works under cc7 without limitations.
 
 systec
-------
+======
+
 - A power loss or a connection loss will trigger a reconnection. For linux, where socketcan is used,
-this works in the same way as for peak. Connections are managed in a systec-global map. 
+this works in the same way as for peak. Connections are managed in a global map. 
 - A software close/open is fully supported and works under cc7 without limitations.
 - For windows the reconnection is NOT WORKING, and it is not clear if it can actually
 be achieved within CanModule. It seems that a library reload is needed to make the module work again.

--- a/Documentation/sphinx-source/connection.rst
+++ b/Documentation/sphinx-source/connection.rst
@@ -20,7 +20,7 @@ firmware reset using the vendor API, through code like:
 
 .. code-block:: c++
 
-	AnaInt32 timeout = 10000; // 10secs
+	AnaInt32 timeout = 12000; // 12secs
 	AnaInt32 anaRet = CANRestart( "192.168.1.10", timeout );
 
 
@@ -39,28 +39,30 @@ The 4th case, software close/open, leads to a deallocation of the connection obj
 created connection. These objects are recorded in a (anagate-global) connection map. The library 
 load object (see standard API) can also be deallocated and recreated.
  
-Nevertheless the Anagate modules tend to firmware-crash if too many close/open are executed too quickly, 
-making a full power-cycle of the module necessary. A delay of 3 seconds between a close and 
-a (re-)open per module is therefore imposed by CanModule to avoid "killing" a module. 
+- the Anagate modules tend to firmware-crash if too many CAN bus close/open are executed too quickly, 
+making a full power-cycle of the module necessary. A delay of 7 seconds between a close and 
+a (re-)open per module is therefore imposed by CanModule to avoid "firmware-crashing" a module. This crash
+occurs independently from the connection timeout. A bigger delay is recommended if it can be afforded:
+lab-tests show a 7sec delay still crashes after 30 consecutive reconnects. These crashes can also
+be related to networking problems but they are difficult to investigate.
 
-- anagate fw reload takes 6 seconds, so adding another 4 seconds is recommended for anagate  
 
 peak
 ----
-The module is receiving power through the USB port, if this connection is lost we need to reconnect.
+- The module is receiving power through the USB port, if this connection is lost we need to reconnect.
 Reconnection works for both normal (fixed) and flexible datarate (FD) modules under linux, as 
-socketcan is used. For windows only
-normal datarate (fixed) are supported, and the reconnection also works for them.
-
-Reconnection takes less than 30sec.
+socketcan is used. For windows only normal datarate (fixed) are supported, and the reconnection 
+also works for them.
+- Reconnection takes less than 30sec.
+- A software close/open is fully supported and works under cc7 without limitations.
 
 systec
 ------
-A power loss or a connection loss will trigger a reconnection. For linux, where socketcan is used,
-this works like for peak. 
-
-For windows the reconnection is NOT WORKING, and it is not clear if it can actually
+- A power loss or a connection loss will trigger a reconnection. For linux, where socketcan is used,
+this works in the same way as for peak. Connections are managed in a systec-global map. 
+- A software close/open is fully supported and works under cc7 without limitations.
+- For windows the reconnection is NOT WORKING, and it is not clear if it can actually
 be achieved within CanModule. It seems that a library reload is needed to make the module work again.
 This feature is therefore DROPPED for now, since also no strong user request for "systec reconnection
-under windows" is presently stated. I tried, using the systec API@windows, but did not manage.
+under windows" is presently stated. I tried, using the systec API@windows as documented, but did not manage.
 

--- a/Documentation/sphinx-source/connection.rst
+++ b/Documentation/sphinx-source/connection.rst
@@ -40,8 +40,10 @@ created connection. These objects are recorded in a (anagate-global) connection 
 load object (see standard API) can also be deallocated and recreated.
  
 Nevertheless the Anagate modules tend to firmware-crash if too many close/open are executed too quickly, 
-making a full power-cycle of the module necessary. A delay of at least 2 seconds between a close and 
-a (re-)open per module is recommended to avoid "killing" the module.  
+making a full power-cycle of the module necessary. A delay of 3 seconds between a close and 
+a (re-)open per module is therefore imposed by CanModule to avoid "killing" a module. 
+
+- anagate fw reload takes 6 seconds, so adding another 4 seconds is recommended for anagate  
 
 peak
 ----

--- a/Documentation/sphinx-source/connection.rst
+++ b/Documentation/sphinx-source/connection.rst
@@ -53,6 +53,9 @@ they are difficult to fix.
 peak
 ====
 
+linux/cc7
+---------
+
 - The module is receiving power through the USB port, if this connection is lost we need to reconnect.
 Reconnection works for both normal (fixed) and flexible datarate (FD) modules under linux, as 
 socketcan is used. For windows only normal datarate (fixed) are supported, and the reconnection 
@@ -60,15 +63,29 @@ also works for them.
 - Reconnection takes less than 30sec.
 - A software close/open is fully supported and works under cc7 without limitations.
 
+windows
+-------
+
+For windows, the sw close/open will typically work several times, and CanModule tries to
+recuperate from a failed initialisation of the USB 10 times. Between successive attempts on a 
+given port a delay of several seconds is needed. This is not great, maybe further progress
+can be made later.   
+
 systec
 ======
 
+linux/cc7
+---------
 - A power loss or a connection loss will trigger a reconnection. For linux, where socketcan is used,
 this works in the same way as for peak. Connections are managed in a global map. 
 - A software close/open is fully supported and works under cc7 and also windows without limitations. 
 If the sequence is too fast (for the environment..) some messages will be lost, but the 
 module recuperates correctly in the following.  
-- For windows the hardware reconnection is NOT WORKING, and it is not clear if it can actually
+
+
+windows
+-------
+For windows the hardware reconnection is NOT WORKING, and it is not clear if it can actually
 be achieved within CanModule. It seems that a library reload is needed to make the module work again.
 This feature is therefore DROPPED for now, since also no strong user request for "systec reconnection
 under windows" is presently stated. I tried, using the systec API@windows as documented, but did not manage.

--- a/Documentation/sphinx-source/connection.rst
+++ b/Documentation/sphinx-source/connection.rst
@@ -4,27 +4,28 @@ Reconnection
 
 CanModule tries to recuperate lost connections automatically, but presently there is no method
 to interrogate CanModule on the status of it's connected modules. This might be added later, though.
+There are up to four ways how to loose a connection, depending on the vendor and type of the module:
+
+(1) power loss
+(2) network or USB loss/interruption
+(3) firmware or "full" module reset through API
+(4) software close/open CAN bus WITHOUT reloading the library.
+
+in short: please avoid (4) and reload the library if possible.
 
 anagate
 =======
 
 The anagate modules are easily and uniquely identified by their IP address, also several modules 
-per CanModule instance are straightforward. An anagate bridge can be disconnected in 4 ways:
-
-1. power loss - power back
-2. network interruption
-3. firmware reset by software through the API
-4. software close CAN bus (followed by sw open)
-
-the firmware reset is NOT implemented in the CanModule, but a module can be remotely accessed and 
-firmware reset using the vendor API, through code like: 
+per CanModule instance are straightforward. The firmware reset (3) is NOT implemented in the CanModule,
+but a module can be remotely accessed and firmware reset using the vendor API, through code like: 
 
 .. code-block:: c++
 
 	AnaInt32 timeout = 12000; // 12secs
 	AnaInt32 anaRet = CANRestart( "192.168.1.10", timeout );
 
-In the cases 1-3 CanModule detects a failure to send a message on a port, and tries to reconnect 
+In the cases (1),(2) CanModule detects a failure to send a message on a port, and tries to reconnect 
 all ports of that module. Sending messages are buffered for ~20secs, and the reconnection 
 takes at least ~20sec, so it takes ~1 minute to reestablish communication. All received CAN frames 
 are lost, and not all sent frames are guaranteed, therefore some care has to be taken when the
@@ -35,9 +36,16 @@ systematically (is it needed?).
 The anagate duo reconnects somewhat faster than the X4/X8 modules, because of firmware differences.
 The whole reconnection can take up to 60 secs until all buffers are cleared, so please be patient.     
 
-The 4th case, software close/open, leads to a deallocation of the connection object, followed by a newly
+The case (4), software close/open, leads to a deallocation of the connection object, followed by a newly
 created connection. These objects are recorded in a (anagate-global) connection map. The library 
 load object (see standard API) can also be deallocated and recreated, but it may also be reused.
+Although the library does not need to be reloaded, strictly speaking, it is recommended to reload it 
+before a (re-)connect:
+
+.. code-block:: c++
+
+		libloader = CanModule::CanLibLoader::createInstance( "an" );
+        cca = libloader->openCanBus( "an:can0:xxx.xxx.xxx.xxx", "125000 0 0 0 0"); 
  
 WARNING: the Anagate modules tend to firmware-crash if too many CAN bus software close/open are 
 executed too quickly, making a full power-cycle of the module necessary. A delay of 7 seconds 
@@ -55,18 +63,16 @@ peak
 
 linux/cc7
 ---------
-
-- The module is receiving power through the USB port, if this connection is lost we need to reconnect.
-Reconnection works for both normal (fixed) and flexible datarate (FD) modules under linux, as 
-socketcan is used. For windows only normal datarate (fixed) are supported, and the reconnection 
-also works for them.
+- power loss is recuperated correctly: the module is receiving power through the USB port, 
+if this connection is lost we need to reconnect. Reconnection works for both normal (fixed) 
+and flexible datarate (FD) modules under linux, as socketcan is used. 
 - Reconnection takes less than 30sec.
 - A software close/open is fully supported and works under cc7 without limitations.
 
 windows
 -------
-
-For windows, the sw close/open will typically work several times, and CanModule tries to
+- power loss is recuperated correctly, but only normal datarate (fixed) are supported 
+- the sw close/open will typically work several times, and CanModule tries to
 recuperate from a failed initialisation of the USB 10 times. Between successive attempts on a 
 given port a delay of several seconds is needed. This is not great, maybe further progress
 can be made later.   
@@ -85,8 +91,10 @@ module recuperates correctly in the following.
 
 windows
 -------
-For windows the hardware reconnection is NOT WORKING, and it is not clear if it can actually
+- the hardware reconnection is NOT WORKING, and it is not clear if it can actually
 be achieved within CanModule. It seems that a library reload is needed to make the module work again.
 This feature is therefore DROPPED for now, since also no strong user request for "systec reconnection
 under windows" is presently stated. I tried, using the systec API@windows as documented, but did not manage.
+
+- the software close/open works correctly, some messages can be lost.
 

--- a/Documentation/sphinx-source/vendors/peak.rst
+++ b/Documentation/sphinx-source/vendors/peak.rst
@@ -7,7 +7,9 @@ both manage the modules through their underlying vendor specific API according t
 Both classes provide the standard generic CanModule API. 
 Here the underlying vendor specific classes and the specific parameters are documented. 
 
-The modules from the families PCAN USB and USB Pro are supported. 
+The modules from the families PCAN USB and USB Pro are supported. For linux, also the flexible 
+datarate (FD) types are supported. The FD types are not supported for windows presently, but they
+could be added in principle if requested.
 
 The connection 
 --------------
@@ -24,7 +26,7 @@ the connection to a specific port for I/O is created by calling
 	:members: createBus, sendMessage
 	
 and communication takes place through peak's open-source PCAN-Basic windows library. Only "plug-and-play"
-modules with USB interface and fixed datarate are supported by CanModule for now. PEAK's flexible datarate (FD)
+modules with USB interface and fixed datarate (non-FD) are supported by CanModule for now. PEAK's flexible datarate (FD)
 modules can be added later on (they need some different API-calls and more complex parameters), and also
 other interfaces like PCI are possible for windows.The implementation is based on the PCAN-Basic driver.
 


### PR DESCRIPTION
* protect global connection maps with mutexes against parallel access
* correct software close/open behaviour as possible without reloading the library. Delays are needed
* prefer reloading the library when software close/open
* works in general, but differences between modules/OS are to be noted, see Documentation/sphinx-result html tree
* some bugs corrected related to reconnect
* tested thouroughly with extra test suite (simpletest)
* lots of commits as always because of X-build chain ;-)
* shall become 1.1.9.5
