### PR TITLE
lib name switching is done in toolchain/app

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,12 +155,7 @@ else()
 	    add_library( ${CANMODULE_LIB_NAME} SHARED ${SRCS} )
 	    target_link_libraries( ${CANMODULE_LIB_NAME} ${LOGIT_LIB} )
     endif()
-    
-IF ( $ENV{CANMODULE_AS_STATIC_AS_POSSIBLE} )
-   target_link_libraries( ${CANMODULE_LIB_NAME} ${BOOST_LIBS_STATIC} )
-ELSE()
-   target_link_libraries( ${CANMODULE_LIB_NAME} ${BOOST_LIBS} )
-ENDIF()
+    target_link_libraries( ${CANMODULE_LIB_NAME} ${BOOST_LIBS} )
      
     # add_subdirectory(CanModuleTest) # we test in the lab
     	


### PR DESCRIPTION
* no changes in functioning, just a small cleanup in the top-level CMakeLists.txt
* builds under ubuntu 18.04LTS (as expected), libs are delivered into nexus
* start inofficial support for ubuntu (to help ISEG using CanModule): add another toolchain to inject which is really the same as cc7.