### PR TITLE
2.0.10devel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+### 2.0.10
+- return cca == NULL if first init is unsuccessful.
+  client needs to check pointer, according to https://its.cern.ch/jira/browse/OPCUA-2248
+- once a port is running, it reconnects as usual (no change)
+
+
 ### 2.0.9
 - took out some remaining debugging lines
 - corrected version to 2.0.9 (showed 2.0.7, was forgotten)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 #  
 #
 cmake_minimum_required(VERSION 3.0)
-project( CanModule LANGUAGES C CXX  VERSION 2.0.9  ) # sets PROJECT_VERSION etc etc
+project( CanModule LANGUAGES C CXX  VERSION 2.0.10  ) # sets PROJECT_VERSION etc etc
 message(STATUS " [${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: CanModule version= ${PROJECT_VERSION}" )
 file(WRITE CanInterface/include/VERSION.h "// VERSION.h - do not edit\n#define CanModule_VERSION \"${PROJECT_VERSION}\"" )
 

--- a/CanInterfaceImplementations/sockcan/SockCanScan.cpp
+++ b/CanInterfaceImplementations/sockcan/SockCanScan.cpp
@@ -701,30 +701,7 @@ bool CSockCanScan::sendRemoteRequest(short cobID)
 	return true;
 }
 
-void testThread(){
-	while(true){
-		std::cout << __FILE__ << " " << __LINE__ << " " << __FUNCTION__ << std::endl;
 
-		struct timespec tim, tim2;
-		tim.tv_sec = 1;
-		tim.tv_nsec = 0;
-		if(nanosleep(&tim , &tim2) < 0 ) {
-			std::cout << __FILE__ << " " << __LINE__ << " " << __FUNCTION__ << "nanosleep failed" << std::endl;;
-		}
-	}
-}
-void testThread2(void *p_voidSockCanScan){
-	while(true){
-		std::cout << __FILE__ << " " << __LINE__ << " " << __FUNCTION__ << std::endl;
-
-		struct timespec tim, tim2;
-		tim.tv_sec = 1;
-		tim.tv_nsec = 0;
-		if(nanosleep(&tim , &tim2) < 0 ) {
-			std::cout << __FILE__ << " " << __LINE__ << " " << __FUNCTION__ << "nanosleep failed" << std::endl;;
-		}
-	}
-}
 
 /**
  * Method that initializes a can bus channel. The following methods called upon the same

--- a/CanLibLoader/src/CanLibLoader.cpp
+++ b/CanLibLoader/src/CanLibLoader.cpp
@@ -92,45 +92,44 @@ CCanAccess* CanLibLoader::openCanBus(string name, string parameters) {
 	 */
 
 	int c = -1;
-	while ( c != 0 ){
-		c = tcca->createBus(name, parameters);
-		LOG(Log::DBG, lh ) << __FUNCTION__ << " createBus returns= " << c;
-		switch ( c ){
-		case 0:{
-			LOG(Log::DBG, lh ) << __FUNCTION__ << " OK: createBus Adding new CCanAccess to the map for: " << name;
-			Diag::insert_maps( this, tcca, parameters );
-			return tcca;
-			break;
-		}
-		case 1:{
-			LOG(Log::DBG, lh ) << __FUNCTION__ << " OK: createBus Skipping existing CCanAccess to the map for: " << name;
-			// Diag::instance().insert_maps( this, tcca, parameters );
-			return tcca; // keep lib object, but only the already existing bus
-			break;
-		}
-		case -1:{
-			LOG(Log::ERR, lh ) << __FUNCTION__ << " Problem opening canBus for: " << name << " : returning NULL";
-			/** we could do 3 things here:
-			* 1. throw an exception and stop everything
-			*   throw std::runtime_error("CanLibLoader::openCanBus: createBus Problem when opening canBus. stop." );
-			* 2. try again looping
-			*   this would go on forever if the bus does not come up
-			* 3. ignore the bus and return 0
-			*   we return NULL in this case and the client has to check the pointer of course
-			*   we decided to do that 6.april.2021 quasar meeting, related to https://its.cern.ch/jira/browse/OPCUA-2248
-			*/
-			return NULL;
-			break;
-		}
-		default:{
-			LOG(Log::WRN, lh ) << __FUNCTION__ << " something else went wrong for: " << name;
-			break;
-		}
-		} // switch
 
-		LOG(Log::WRN, lh ) << __FUNCTION__ << " try again in a moment: " << name;
-		CanModule::ms_sleep( 2000 );
+	c = tcca->createBus(name, parameters);
+	LOG(Log::DBG, lh ) << __FUNCTION__ << " createBus returns= " << c;
+	switch ( c ){
+	case 0:{
+		LOG(Log::DBG, lh ) << __FUNCTION__ << " OK: createBus Adding new CCanAccess to the map for: " << name;
+		Diag::insert_maps( this, tcca, parameters );
+		return tcca;
+		break;
 	}
+	case 1:{
+		LOG(Log::DBG, lh ) << __FUNCTION__ << " OK: createBus Skipping existing CCanAccess to the map for: " << name;
+		// Diag::instance().insert_maps( this, tcca, parameters );
+		return tcca; // keep lib object, but only the already existing bus
+		break;
+	}
+	case -1:{
+		LOG(Log::ERR, lh ) << __FUNCTION__ << " Problem opening canBus for: " << name << " : returning NULL";
+		/** we could do 3 things here:
+		 * 1. throw an exception and stop everything
+		 *   throw std::runtime_error("CanLibLoader::openCanBus: createBus Problem when opening canBus. stop." );
+		 * 2. try again looping
+		 *   this would go on forever if the bus does not come up
+		 * 3. ignore the bus and return 0
+		 *   we return NULL in this case and the client has to check the pointer of course
+		 *   we decided to do that 6.april.2021 quasar meeting, related to https://its.cern.ch/jira/browse/OPCUA-2248
+		 */
+		return NULL;
+		break;
+	}
+	default:{
+		LOG(Log::WRN, lh ) << __FUNCTION__ << " something else went wrong for: " << name << " try again";
+		break;
+	}
+	} // switch
+
+	LOG(Log::WRN, lh ) << __FUNCTION__ << " try again in a moment: " << name;
+	CanModule::ms_sleep( 2000 );
 	// never reached
 	return 0;
 }

--- a/CanLibLoader/src/CanLibLoader.cpp
+++ b/CanLibLoader/src/CanLibLoader.cpp
@@ -90,10 +90,7 @@ CCanAccess* CanLibLoader::openCanBus(string name, string parameters) {
 	 * @param parameters: Different parameters used for the initialisation. For using the default parameters just set this to "Unspecified"
 	 *
 	 */
-
-	int c = -1;
-
-	c = tcca->createBus(name, parameters);
+	int c = tcca->createBus(name, parameters);
 	LOG(Log::DBG, lh ) << __FUNCTION__ << " createBus returns= " << c;
 	switch ( c ){
 	case 0:{
@@ -104,7 +101,6 @@ CCanAccess* CanLibLoader::openCanBus(string name, string parameters) {
 	}
 	case 1:{
 		LOG(Log::DBG, lh ) << __FUNCTION__ << " OK: createBus Skipping existing CCanAccess to the map for: " << name;
-		// Diag::instance().insert_maps( this, tcca, parameters );
 		return tcca; // keep lib object, but only the already existing bus
 		break;
 	}
@@ -123,14 +119,13 @@ CCanAccess* CanLibLoader::openCanBus(string name, string parameters) {
 		break;
 	}
 	default:{
-		LOG(Log::WRN, lh ) << __FUNCTION__ << " something else went wrong for: " << name << " try again";
+		LOG(Log::WRN, lh ) << __FUNCTION__ << " something else went wrong for: " << name << " : returning NULL";
+		return NULL;
 		break;
 	}
 	} // switch
 
-	LOG(Log::WRN, lh ) << __FUNCTION__ << " try again in a moment: " << name;
-	CanModule::ms_sleep( 2000 );
 	// never reached
-	return 0;
+	return NULL;
 }
 }

--- a/CanLibLoader/src/CanLibLoader.cpp
+++ b/CanLibLoader/src/CanLibLoader.cpp
@@ -109,16 +109,17 @@ CCanAccess* CanLibLoader::openCanBus(string name, string parameters) {
 			break;
 		}
 		case -1:{
-			LOG(Log::WRN, lh ) << __FUNCTION__ << " createBus Problem opening canBus for: " << name;
+			LOG(Log::ERR, lh ) << __FUNCTION__ << " Problem opening canBus for: " << name << " : returning NULL";
 			/** we could do 3 things here:
 			* 1. throw an exception and stop everything
 			*   throw std::runtime_error("CanLibLoader::openCanBus: createBus Problem when opening canBus. stop." );
 			* 2. try again looping
 			*   this would go on forever if the bus does not come up
-			* 3. ignore the bus
-			*   what do we return in this case ... null... but that is dangerous, and maybe not what we want.
+			* 3. ignore the bus and return 0
+			*   we return NULL in this case and the client has to check the pointer of course
+			*   we decided to do that 6.april.2021 quasar meeting, related to https://its.cern.ch/jira/browse/OPCUA-2248
 			*/
-			// return NULL;
+			return NULL;
 			break;
 		}
 		default:{


### PR DESCRIPTION
- at lib init, if port init fails, return NULL. Clients have to check this
- reconnection behavior unaffected: once a port is up, it can fail during runtime and will be reconnected as specified
- all tests in cc7 also done now, looks good. certain performance problems remain
- had to rebuild and reinstall drivers for updated kernel for systec and peak, according to documentation. No problem though.
- found and suppressed some dead debugging code