### PR TITLE
2.0.19devel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - OPCUA-2584: rx/tx counting in the handler, for now, to improve err reporting already
 
 ### 2.0.19 [7.april.2022]
-- getPortStatus() for "sock" should make a system call to the network layer each time it is invoked
+- getPortStatus() for "sock" should make a system call to the network layer each time it is invoked, and NOT be part of the statistics any more.
+  makes more sense anyway.
 
 
 ### 2.0.18 [march.2022]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### in progress
 
-- OPCUA-2614: extended messages, do we need an option ? 
 - OPCUA-2584: rx/tx counting in the handler, for now, to improve err reporting already
+
+### 2.0.19 [7.april.2022]
+- getPortStatus() for "sock" should make a system call to the network layer each time it is invoked
+
 
 ### 2.0.18 [march.2022]
 - fix popen return type (cs9)

--- a/CanInterface/include/CanStatistics.h
+++ b/CanInterface/include/CanStatistics.h
@@ -90,17 +90,6 @@ public:
 	void setTimeSinceReceived()    { m_dreceived    = high_resolution_clock::now();	}
 	void setTimeSinceTransmitted() { m_dtransmitted = high_resolution_clock::now();	}
 
-	/*
-	 * acquire the latest status of the CAN bus, from as-low-as-possible SW layer,
-	 * and put it into a bitpattern.
-	 * socketcan: netlink layer IFLA states STATUS and others...
-	 * anagate:
-	 * peak (windows):
-	 * systec (windows):
-	 */
-	uint32_t portStatus() { return( m_portStatus ); }
-	void setPortStatus( uint32_t s ) { m_internals.m_state = s;}
-	void encodeCanModuleStatus();
 	void operator=(const CanStatistics & other);  // not default, because of atomic data
 
 private:
@@ -118,7 +107,7 @@ private:
 	std::atomic_uint_least32_t m_receivedOctets;
 
 	high_resolution_clock::time_point m_dnow, m_dreceived, m_dtransmitted, m_dopen;
-	uint32_t m_portStatus; // encoded status for all vendors
+	//uint32_t m_portStatus; // encoded status for all vendors
 
 	//! Following is encapsulated as a class, to provide sane copying in assignment operator
 	class Internals
@@ -129,7 +118,6 @@ private:
 		//! Bus load derived from #TX and #RX packages
 		float m_busLoad;
 		system_clock::time_point m_observationStart;
-		uint32_t m_state; // from IFLA socketcan: can_get_state(..)
 	};
 	Internals m_internals;
 

--- a/CanInterface/src/CanStatistics.cpp
+++ b/CanInterface/src/CanStatistics.cpp
@@ -37,8 +37,7 @@ namespace CanModule
 		m_transmitted(0),
 		m_received(0),
 		m_transmittedOctets(0),
-		m_receivedOctets(0),
-		m_portStatus(0)
+		m_receivedOctets(0)
 	{}
 
 	void CanStatistics::beginNewRun()
@@ -49,28 +48,6 @@ namespace CanModule
 		m_transmittedOctets = 0;
 		m_receivedOctets = 0;
 	}
-
-	/**
-	 * encode a port status from the various informations of the CAN system
-	 *
-	 * the whole netlink structs are available. We can code anything as long as
-	 * it is usefully making sense for all vendors. see void CSockCanScan::updateBusStatus(){
-	 * but lets just copy the _state for now, which is a simple enum:
-	 *
-	 * enum can_state {
-	 * 	CAN_STATE_ERROR_ACTIVE = 0,	 RX/TX error count < 96
-	 * 	CAN_STATE_ERROR_WARNING,	 RX/TX error count < 128
-	 * 	CAN_STATE_ERROR_PASSIVE,	 RX/TX error count < 256
-	 * 	CAN_STATE_BUS_OFF,		 RX/TX error count >= 256
-	 * 	CAN_STATE_STOPPED,		 Device is stopped
-	 * 	CAN_STATE_SLEEPING,		 Device is sleeping
-	 * 	CAN_STATE_MAX
-	 * 	};
-	 */
-	void CanStatistics::encodeCanModuleStatus(){
-		m_portStatus = m_internals.m_state;
-	}
-
 	void CanStatistics::computeDerived(unsigned int baudRate)
 	{
 		system_clock::time_point tnom = system_clock::now(); 
@@ -119,7 +96,5 @@ namespace CanModule
 		this->m_dtransmitted = other.m_dtransmitted;
 		this->m_dopen = other.m_dopen;
 		this->m_dnow = other.m_dnow;
-
-		this->m_portStatus = other.m_portStatus;
 	}
 }


### PR DESCRIPTION
- getPortStatus() for "sock" should make a system call to the network layer each time it is invoked, and NOT be part of the statistics any more.
  makes more sense anyway.
