### PR TITLE
Devel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 - OPCUA-2584: rx/tx counting in the handler, for now, to improve err reporting already
 
 ### 2.0.19 [7.april.2022]
-- getPortStatus() for "sock" should make a system call to the network layer each time it is invoked, and NOT be part of the statistics any more.
-  makes more sense anyway.
-
+- gettimeofday/C++ chrono cleanup to modernize code
+- fixing OPCUA-2691: mini release to fix getPortStatus() for "sock", provide a more direct approach
+  Now it just goes out directly and does a can_get_state() each time it is invoked, and wraps the result into the unified port as before status.
+  port status is NOT part of the statistics any more, suppressed all code related.
+  port status is updated each call, not each 10th call or after 10 seconds
+  frankly, this makes more sense as well, must have had a bad day when coding the previous implementation ;-)
+  not really tested, issue stays open until the OPCUA can open server confirms it. Pretty simple though, should work as-is.
 
 ### 2.0.18 [march.2022]
 - fix popen return type (cs9)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,16 +133,16 @@ IF (WIN32)
 ELSE()
 	SET( CAN_LIBRARY_LOADER_PLATFORM_IMPL CanLibLoader/src/CanLibLoaderLin.cpp)
 	SET( CAN_LIBRARY_LOADER_PLATFORM_IMPL_HEADER CanLibLoader/include/CanLibLoaderLin.h)
-	SET( CAN_LIBRARY_GETTIMEOFDAY )
-	SET( CAN_LIBRARY_GETTIMEOFDAY_HEADER )
+#	SET( CAN_LIBRARY_GETTIMEOFDAY )
+#	SET( CAN_LIBRARY_GETTIMEOFDAY_HEADER )
 	# use RUNPATH instead of RPATH -Wl,--disable-new-dtags does not work on g++ (GCC) 4.8.5 20150623 (Red Hat 4.8.5-39)
     SET( CMAKE_SKIP_RPATH TRUE )
 	SET( CANMODULE_RPATHS "-Wl,-rpath,./ -Wl,-rpath,./lib -Wl,-rpath,/usr/local/lib" )
 ENDIF()
 
 # versioning burnt into the bins, but don't overwrite in the build if exists
-if (NOT EXISTS ${PROJECT_BINARY_DIR}/generated/VERSION.h )
-	file(WRITE ${PROJECT_BINARY_DIR}/generated/VERSION.h "// VERSION.h - do not edit\n#define CanModule_VERSION \"${PROJECT_VERSION}\"" )
+if (NOT EXISTS ${PROJECT_SOURCE_DIR}/CanInterface/include/VERSION.h )
+	file(WRITE ${PROJECT_SOURCE_DIR}/CanInterface/include/VERSION.h "// VERSION.h - do not edit\n#define CanModule_VERSION \"${PROJECT_VERSION}\"" )
 	message(STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: generated VERSION.h into ${PROJECT_BINARY_DIR}/generated")
 ELSE()
 	message(STATUS "[${CMAKE_CURRENT_LIST_FILE}:${CMAKE_CURRENT_LIST_LINE}]: CanModule VERSION.h exists already in ${PROJECT_BINARY_DIR}/generated, don't touch it")
@@ -164,17 +164,16 @@ SET( SRCS
 		CanInterface/include/CanMessage.h
 		CanInterface/src/CCanAccess.cpp
 		CanInterface/include/CCanAccess.h
-		${CAN_LIBRARY_GETTIMEOFDAY}
-		${CAN_LIBRARY_GETTIMEOFDAY_HEADER}	
-		${PROJECT_BINARY_DIR}/generated/VERSION.h	
+#		${CAN_LIBRARY_GETTIMEOFDAY}
+#		${CAN_LIBRARY_GETTIMEOFDAY_HEADER}	
+		${PROJECT_SOURCE_DIR}/CanInterface/include/VERSION.h	
 )
 
 include_directories( 
 	include 
 	CanLibLoader/include
 	CanInterface/include 
-	Diagnostic/include 
-	${PROJECT_BINARY_DIR}/generated
+	Diagnostic/include 	
 )
 
 

--- a/CanInterface/include/CCanAccess.h
+++ b/CanInterface/include/CCanAccess.h
@@ -558,12 +558,6 @@ protected:
 		duration<double, micro> time_span = duration_cast<duration<double, micro>>(m_dnow - m_dopen);
 		if ( time_span.count() / 1000 > m_timeoutOnReception ) return true;
 		else return false;
-
-
-		//m_now = convertTimepointToTimeval( std::chrono::system_clock::now());
-		//double delta = (double) ( m_now.tv_sec - m_dreceived.tv_sec);
-		//if ( delta > m_timeoutOnReception ) return true;
-		//else return false;
 	}
 
 	/**
@@ -571,11 +565,9 @@ protected:
 	 */
 	void resetTimeoutOnReception() {
 		m_dreceived = high_resolution_clock::now();
-		//m_dreceived = convertTimepointToTimeval( std::chrono::system_clock::now());
 	}
 	void resetTimeNow() {
 		m_dnow = high_resolution_clock::now();
-		//m_now = convertTimepointToTimeval( std::chrono::system_clock::now());
 	}
 
 private:

--- a/CanInterface/include/CCanAccess.h
+++ b/CanInterface/include/CCanAccess.h
@@ -574,12 +574,12 @@ private:
 	Log::LogComponentHandle m_lh; // s_lh ?!? problem with windows w.t.f.
 	LogItInstance* m_logItRemoteInstance;
 
-#ifdef _WIN32
+//#ifdef _WIN32
 	SYSTEMTIME m_now, m_dreceived, m_dtransmitted, m_dopen;
-#else
+//#else
 	struct timeval m_now, m_dreceived;
 	struct timezone m_tz;
-#endif
+//#endif
 
 };
 };

--- a/CanInterface/include/CCanAccess.h
+++ b/CanInterface/include/CCanAccess.h
@@ -579,18 +579,8 @@ protected:
 	}
 
 private:
-	//boost::signals2::connection m_signal_connection; // seems unused
-	//int m_connectionIndex; // seems unused
-	Log::LogComponentHandle m_lh; // s_lh ?!? problem with windows w.t.f.
+	Log::LogComponentHandle m_lh;
 	LogItInstance* m_logItRemoteInstance;
-
-//#ifdef _WIN32
-//	SYSTEMTIME m_now, m_dreceived, m_dtransmitted, m_dopen;
-//#else
-//	struct timeval m_now, m_dreceived, m_dtransmitted, m_dopen;
-//	struct timezone m_tz;
-//#endif
-
 	high_resolution_clock::time_point m_dnow, m_dreceived, m_dtransmitted, m_dopen;
 
 };

--- a/CanInterface/include/CCanAccess.h
+++ b/CanInterface/include/CCanAccess.h
@@ -42,8 +42,7 @@
 #include "CanMessage.h"
 #include "CanStatistics.h"
 #include "CanModuleUtils.h"
-
-#include "xxxVERSION.h.xxx"
+#include "VERSION.h"
 
 
 /*

--- a/CanInterface/include/CCanAccess.h
+++ b/CanInterface/include/CCanAccess.h
@@ -553,7 +553,6 @@ protected:
 	 * compared to the last received message, are we in timeout?
 	 */
 	bool hasTimeoutOnReception() {
-
 		m_dnow = high_resolution_clock::now();
 		duration<double, micro> time_span = duration_cast<duration<double, micro>>(m_dnow - m_dopen);
 		if ( time_span.count() / 1000 > m_timeoutOnReception ) return true;

--- a/CanInterface/include/CCanAccess.h
+++ b/CanInterface/include/CCanAccess.h
@@ -575,7 +575,7 @@ private:
 	LogItInstance* m_logItRemoteInstance;
 
 //#ifdef _WIN32
-	SYSTEMTIME m_now, m_dreceived, m_dtransmitted, m_dopen;
+//	SYSTEMTIME m_now, m_dreceived, m_dtransmitted, m_dopen;
 //#else
 	struct timeval m_now, m_dreceived;
 	struct timezone m_tz;

--- a/CanInterface/include/CCanAccess.h
+++ b/CanInterface/include/CCanAccess.h
@@ -43,7 +43,7 @@
 #include "CanStatistics.h"
 #include "CanModuleUtils.h"
 
-#include "VERSION.h"
+#include "xxxVERSION.h.xxx"
 
 
 /*

--- a/CanInterface/include/CCanAccess.h
+++ b/CanInterface/include/CCanAccess.h
@@ -29,8 +29,6 @@
 #include <thread>
 #include <string>
 #include <atomic>
-#include <chrono>
-
 #include <mutex>
 #include <condition_variable>
 

--- a/CanInterface/include/CCanAccess.h
+++ b/CanInterface/include/CCanAccess.h
@@ -29,6 +29,7 @@
 #include <thread>
 #include <string>
 #include <atomic>
+#include <chrono>
 
 #include <mutex>
 #include <condition_variable>
@@ -552,20 +553,29 @@ protected:
 	 * compared to the last received message, are we in timeout?
 	 */
 	bool hasTimeoutOnReception() {
-		m_now = convertTimepointToTimeval( std::chrono::system_clock::now());
-		double delta = (double) ( m_now.tv_sec - m_dreceived.tv_sec);
-		if ( delta > m_timeoutOnReception ) return true;
+
+		m_dnow = high_resolution_clock::now();
+		duration<double, micro> time_span = duration_cast<duration<double, micro>>(m_dnow - m_dopen);
+		if ( time_span.count() / 1000 > m_timeoutOnReception ) return true;
 		else return false;
+
+
+		//m_now = convertTimepointToTimeval( std::chrono::system_clock::now());
+		//double delta = (double) ( m_now.tv_sec - m_dreceived.tv_sec);
+		//if ( delta > m_timeoutOnReception ) return true;
+		//else return false;
 	}
 
 	/**
 	 * reset the internal reconnection timeout counter
 	 */
 	void resetTimeoutOnReception() {
-		m_dreceived = convertTimepointToTimeval( std::chrono::system_clock::now());
+		m_dreceived = high_resolution_clock::now();
+		//m_dreceived = convertTimepointToTimeval( std::chrono::system_clock::now());
 	}
 	void resetTimeNow() {
-		m_now = convertTimepointToTimeval( std::chrono::system_clock::now());
+		m_dnow = high_resolution_clock::now();
+		//m_now = convertTimepointToTimeval( std::chrono::system_clock::now());
 	}
 
 private:
@@ -577,9 +587,11 @@ private:
 //#ifdef _WIN32
 //	SYSTEMTIME m_now, m_dreceived, m_dtransmitted, m_dopen;
 //#else
-	struct timeval m_now, m_dreceived, m_dtransmitted, m_dopen;
+//	struct timeval m_now, m_dreceived, m_dtransmitted, m_dopen;
 //	struct timezone m_tz;
 //#endif
+
+	high_resolution_clock::time_point m_dnow, m_dreceived, m_dtransmitted, m_dopen;
 
 };
 };

--- a/CanInterface/include/CCanAccess.h
+++ b/CanInterface/include/CCanAccess.h
@@ -40,6 +40,8 @@
 
 #include "CanMessage.h"
 #include "CanStatistics.h"
+#include "CanModuleUtils.h"
+
 #include "VERSION.h"
 
 
@@ -550,13 +552,8 @@ protected:
 	 * compared to the last received message, are we in timeout?
 	 */
 	bool hasTimeoutOnReception() {
-#ifdef _WIN32
-		GetSystemTime(&m_now);
-		double delta = m_now.wSecond- m_dreceived.wSecond ;
-#else
-		gettimeofday( &m_now, &m_tz);
+		m_now = convertTimepointToTimeval( std::chrono::system_clock::now());
 		double delta = (double) ( m_now.tv_sec - m_dreceived.tv_sec);
-#endif
 		if ( delta > m_timeoutOnReception ) return true;
 		else return false;
 	}
@@ -565,18 +562,10 @@ protected:
 	 * reset the internal reconnection timeout counter
 	 */
 	void resetTimeoutOnReception() {
-#ifdef _WIN32
-		GetSystemTime(&m_dreceived);
-#else
-		gettimeofday( &m_dreceived, &m_tz);
-#endif
+		m_dreceived = convertTimepointToTimeval( std::chrono::system_clock::now());
 	}
 	void resetTimeNow() {
-#ifdef _WIN32
-		GetSystemTime(&m_now);
-#else
-		gettimeofday( &m_now, &m_tz);
-#endif
+		m_now = convertTimepointToTimeval( std::chrono::system_clock::now());
 	}
 
 private:

--- a/CanInterface/include/CCanAccess.h
+++ b/CanInterface/include/CCanAccess.h
@@ -577,8 +577,8 @@ private:
 //#ifdef _WIN32
 //	SYSTEMTIME m_now, m_dreceived, m_dtransmitted, m_dopen;
 //#else
-	struct timeval m_now, m_dreceived;
-	struct timezone m_tz;
+	struct timeval m_now, m_dreceived, m_dtransmitted, m_dopen;
+//	struct timezone m_tz;
 //#endif
 
 };

--- a/CanInterface/include/CanModuleUtils.h
+++ b/CanInterface/include/CanModuleUtils.h
@@ -76,7 +76,6 @@ namespace CanModule
 	std::chrono::system_clock::time_point convertTimevalToTimepoint(const timeval &t1);
 	double CanModulesubtractTimeval(const std::chrono::system_clock::time_point &t1, const std::chrono::system_clock::time_point &t2);
 	std::chrono::system_clock::time_point currentTimeTimeval();
-	//UaString bytesToUaString( const unsigned char* data, unsigned int len );
 
 	std::string CanModuleerrnoToString();
 }

--- a/CanInterface/include/CanModuleUtils.h
+++ b/CanInterface/include/CanModuleUtils.h
@@ -73,11 +73,10 @@ namespace CanModule
 	};
 
 	timeval convertTimepointToTimeval(const std::chrono::system_clock::time_point &t1);
-#if 0
 	std::chrono::system_clock::time_point convertTimevalToTimepoint(const timeval &t1);
-	double CanModulesubtractTimeval(const std::chrono::system_clock::time_point &t1, const std::chrono::system_clock::time_point &t2);
+//	double CanModulesubtractTimeval(const std::chrono::system_clock::time_point &t1, const std::chrono::system_clock::time_point &t2);
 	std::chrono::system_clock::time_point currentTimeTimeval();
-#endif
+
 	std::string CanModuleerrnoToString();
 }
 #endif /* UTILS_H_ */

--- a/CanInterface/include/CanModuleUtils.h
+++ b/CanInterface/include/CanModuleUtils.h
@@ -74,9 +74,7 @@ namespace CanModule
 
 	timeval convertTimepointToTimeval(const std::chrono::system_clock::time_point &t1);
 	std::chrono::system_clock::time_point convertTimevalToTimepoint(const timeval &t1);
-//	double CanModulesubtractTimeval(const std::chrono::system_clock::time_point &t1, const std::chrono::system_clock::time_point &t2);
 	std::chrono::system_clock::time_point currentTimeTimeval();
-
 	std::string CanModuleerrnoToString();
 }
 #endif /* UTILS_H_ */

--- a/CanInterface/include/CanModuleUtils.h
+++ b/CanInterface/include/CanModuleUtils.h
@@ -75,11 +75,14 @@ namespace CanModule
 
 #ifdef _WIN32
 	timeval convertTimepointToTimeval(const std::chrono::steady_clock::time_point &t1);
+	std::chrono::steady_clock::time_point convertTimevalToTimepoint(const timeval &t1);
+	std::chrono::steady_clock::time_point currentTimeTimeval();
 #else
 	timeval convertTimepointToTimeval(const std::chrono::system_clock::time_point &t1);
-#endif
 	std::chrono::system_clock::time_point convertTimevalToTimepoint(const timeval &t1);
 	std::chrono::system_clock::time_point currentTimeTimeval();
+#endif
+
 	std::string CanModuleerrnoToString();
 }
 #endif /* UTILS_H_ */

--- a/CanInterface/include/CanModuleUtils.h
+++ b/CanInterface/include/CanModuleUtils.h
@@ -71,12 +71,12 @@ namespace CanModule
 		}
 
 	};
-
+#if 0
 	timeval convertTimepointToTimeval(const std::chrono::system_clock::time_point &t1);
 	std::chrono::system_clock::time_point convertTimevalToTimepoint(const timeval &t1);
 	double CanModulesubtractTimeval(const std::chrono::system_clock::time_point &t1, const std::chrono::system_clock::time_point &t2);
 	std::chrono::system_clock::time_point currentTimeTimeval();
-
+#endif
 	std::string CanModuleerrnoToString();
 }
 #endif /* UTILS_H_ */

--- a/CanInterface/include/CanModuleUtils.h
+++ b/CanInterface/include/CanModuleUtils.h
@@ -73,11 +73,11 @@ namespace CanModule
 	};
 
 
-//#ifdef _WIN32
-//	timeval convertTimepointToTimeval(const std::chrono::steady_clock::time_point &t1);
-//#else
+#ifdef _WIN32
+	timeval convertTimepointToTimeval(const std::chrono::steady_clock::time_point &t1);
+#else
 	timeval convertTimepointToTimeval(const std::chrono::system_clock::time_point &t1);
-//#endif
+#endif
 	std::chrono::system_clock::time_point convertTimevalToTimepoint(const timeval &t1);
 	std::chrono::system_clock::time_point currentTimeTimeval();
 	std::string CanModuleerrnoToString();

--- a/CanInterface/include/CanModuleUtils.h
+++ b/CanInterface/include/CanModuleUtils.h
@@ -23,11 +23,11 @@
 #ifndef CanModuleUTILS_H_
 #define CanModuleUTILS_H_
 
-#ifdef _WIN32
-#include <Winsock2.h>
-#else
-#include <sys/time.h>
-#endif
+//#ifdef _WIN32
+//#include <Winsock2.h>
+//#else
+//#include <sys/time.h>
+//#endif
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -73,6 +73,7 @@ namespace CanModule
 	};
 
 	timeval convertTimepointToTimeval(const std::chrono::system_clock::time_point &t1);
+	timeval convertTimepointToTimeval(const std::chrono::steady_clock::time_point &t1);
 	std::chrono::system_clock::time_point convertTimevalToTimepoint(const timeval &t1);
 	std::chrono::system_clock::time_point currentTimeTimeval();
 	std::string CanModuleerrnoToString();

--- a/CanInterface/include/CanModuleUtils.h
+++ b/CanInterface/include/CanModuleUtils.h
@@ -71,8 +71,9 @@ namespace CanModule
 		}
 
 	};
-#if 0
+
 	timeval convertTimepointToTimeval(const std::chrono::system_clock::time_point &t1);
+#if 0
 	std::chrono::system_clock::time_point convertTimevalToTimepoint(const timeval &t1);
 	double CanModulesubtractTimeval(const std::chrono::system_clock::time_point &t1, const std::chrono::system_clock::time_point &t2);
 	std::chrono::system_clock::time_point currentTimeTimeval();

--- a/CanInterface/include/CanModuleUtils.h
+++ b/CanInterface/include/CanModuleUtils.h
@@ -72,8 +72,12 @@ namespace CanModule
 
 	};
 
-	timeval convertTimepointToTimeval(const std::chrono::system_clock::time_point &t1);
+
+#ifdef _WIN32
 	timeval convertTimepointToTimeval(const std::chrono::steady_clock::time_point &t1);
+#else
+	timeval convertTimepointToTimeval(const std::chrono::system_clock::time_point &t1);
+#endif
 	std::chrono::system_clock::time_point convertTimevalToTimepoint(const timeval &t1);
 	std::chrono::system_clock::time_point currentTimeTimeval();
 	std::string CanModuleerrnoToString();

--- a/CanInterface/include/CanModuleUtils.h
+++ b/CanInterface/include/CanModuleUtils.h
@@ -73,11 +73,11 @@ namespace CanModule
 	};
 
 
-#ifdef _WIN32
-	timeval convertTimepointToTimeval(const std::chrono::steady_clock::time_point &t1);
-#else
+//#ifdef _WIN32
+//	timeval convertTimepointToTimeval(const std::chrono::steady_clock::time_point &t1);
+//#else
 	timeval convertTimepointToTimeval(const std::chrono::system_clock::time_point &t1);
-#endif
+//#endif
 	std::chrono::system_clock::time_point convertTimevalToTimepoint(const timeval &t1);
 	std::chrono::system_clock::time_point currentTimeTimeval();
 	std::string CanModuleerrnoToString();

--- a/CanInterface/include/CanModuleUtils.h
+++ b/CanInterface/include/CanModuleUtils.h
@@ -23,11 +23,11 @@
 #ifndef CanModuleUTILS_H_
 #define CanModuleUTILS_H_
 
-//#ifdef _WIN32
-//#include <Winsock2.h>
-//#else
-//#include <sys/time.h>
-//#endif
+#ifdef _WIN32
+#include <Winsock2.h>
+#else
+#include <sys/time.h>
+#endif
 #include <sstream>
 #include <stdexcept>
 #include <string>

--- a/CanInterface/include/CanStatistics.h
+++ b/CanInterface/include/CanStatistics.h
@@ -107,7 +107,6 @@ private:
 	std::atomic_uint_least32_t m_receivedOctets;
 
 	high_resolution_clock::time_point m_hrnow, m_hrreceived, m_hrtransmitted, m_hropen;
-	//uint32_t m_portStatus; // encoded status for all vendors
 
 	//! Following is encapsulated as a class, to provide sane copying in assignment operator
 	class Internals

--- a/CanInterface/include/CanStatistics.h
+++ b/CanInterface/include/CanStatistics.h
@@ -24,7 +24,7 @@
 #ifndef CANINTERFACE_SOCKCAN_CANSTATISTICS_H_
 #define CANINTERFACE_SOCKCAN_CANSTATISTICS_H_
 
-
+/**
 #ifdef _WIN32
 #	include <atomic>
 #	include <time.h>
@@ -40,8 +40,10 @@
 #	endif // GCC_VERSION
 #	include <sys/time.h>
 #endif
-#include "ExportDefinition.h"
+**/
 
+#include "ExportDefinition.h"
+#include <atomic>
 #include <chrono>
 using namespace std;
 using namespace std::chrono;

--- a/CanInterface/include/CanStatistics.h
+++ b/CanInterface/include/CanStatistics.h
@@ -72,23 +72,23 @@ public:
 
 
 	double timeSinceReceived() {
-		m_dnow = high_resolution_clock::now();
-		duration<double, micro> time_span = duration_cast<duration<double, micro>>(m_dnow - m_dreceived);
+		m_hrnow = high_resolution_clock::now();
+		duration<double, micro> time_span = duration_cast<duration<double, micro>>(m_hrnow - m_hrreceived);
 		return ( time_span.count() / 1000 );
 	}
 	double timeSinceTransmitted() {
-		m_dnow = high_resolution_clock::now();
-		duration<double, micro> time_span = duration_cast<duration<double, micro>>(m_dnow - m_dtransmitted);
+		m_hrnow = high_resolution_clock::now();
+		duration<double, micro> time_span = duration_cast<duration<double, micro>>(m_hrnow - m_hrtransmitted);
 		return ( time_span.count() / 1000 );
 	}
 	double timeSinceOpened() {
-		m_dnow = high_resolution_clock::now();
-		duration<double, micro> time_span = duration_cast<duration<double, micro>>(m_dnow - m_dopen);
+		m_hrnow = high_resolution_clock::now();
+		duration<double, micro> time_span = duration_cast<duration<double, micro>>(m_hrnow - m_hropen);
 		return ( time_span.count() / 1000 );
 	}
-	void setTimeSinceOpened()      { m_dopen        = high_resolution_clock::now();	}
-	void setTimeSinceReceived()    { m_dreceived    = high_resolution_clock::now();	}
-	void setTimeSinceTransmitted() { m_dtransmitted = high_resolution_clock::now();	}
+	void setTimeSinceOpened()      { m_hropen        = high_resolution_clock::now();	}
+	void setTimeSinceReceived()    { m_hrreceived    = high_resolution_clock::now();	}
+	void setTimeSinceTransmitted() { m_hrtransmitted = high_resolution_clock::now();	}
 
 	void operator=(const CanStatistics & other);  // not default, because of atomic data
 
@@ -106,7 +106,7 @@ private:
 	std::atomic_uint_least32_t m_transmittedOctets;
 	std::atomic_uint_least32_t m_receivedOctets;
 
-	high_resolution_clock::time_point m_dnow, m_dreceived, m_dtransmitted, m_dopen;
+	high_resolution_clock::time_point m_hrnow, m_hrreceived, m_hrtransmitted, m_hropen;
 	//uint32_t m_portStatus; // encoded status for all vendors
 
 	//! Following is encapsulated as a class, to provide sane copying in assignment operator

--- a/CanInterface/include/VERSION.h
+++ b/CanInterface/include/VERSION.h
@@ -1,2 +1,0 @@
-// VERSION.h - do not edit
-#define CanModule_VERSION "2.0.16"

--- a/CanInterface/include/VERSION.h
+++ b/CanInterface/include/VERSION.h
@@ -1,0 +1,2 @@
+// VERSION.h - do not edit
+#define CANMODULE_VERSION "2.0.19"

--- a/CanInterface/include/VERSION.h
+++ b/CanInterface/include/VERSION.h
@@ -1,2 +1,2 @@
 // VERSION.h - do not edit
-#define CANMODULE_VERSION "2.0.19"
+#define CanModule_VERSION "2.0.19"

--- a/CanInterface/include/VERSION.h
+++ b/CanInterface/include/VERSION.h
@@ -1,2 +1,0 @@
-// VERSION.h - do not edit
-#define CanModule_VERSION "2.0.19"

--- a/CanInterface/src/CanModuleUtils.cpp
+++ b/CanInterface/src/CanModuleUtils.cpp
@@ -40,7 +40,7 @@ namespace CanModule
 		return std::string(strerror_r(errno, buf, max_len - 1));
 #endif
 	}
-#if 0
+
 	timeval convertTimepointToTimeval(const std::chrono::system_clock::time_point &t1)
 	{
 		timeval dest;
@@ -49,7 +49,7 @@ namespace CanModule
 		dest.tv_usec = (millisecs.count() % 1000) * 1000;
 		return dest;
 	}
-
+#if 0
 	std::chrono::system_clock::time_point convertTimevalToTimepoint(const timeval &t1)
 	{
 		auto d = std::chrono::seconds(t1.tv_sec) + std::chrono::nanoseconds(t1.tv_usec);

--- a/CanInterface/src/CanModuleUtils.cpp
+++ b/CanInterface/src/CanModuleUtils.cpp
@@ -41,12 +41,12 @@ namespace CanModule
 #endif
 	}
 
-//#ifdef _WIN32
+#ifdef _WIN32
 	// overload for windows implementation errors on chrono
-//	timeval convertTimepointToTimeval(const std::chrono::steady_clock::time_point &t1)
-//#else
+	timeval convertTimepointToTimeval(const std::chrono::steady_clock::time_point &t1)
+#else
 	timeval convertTimepointToTimeval(const std::chrono::system_clock::time_point &t1)
-//#endif
+#endif
 	{
 		timeval dest;
 		auto millisecs = std::chrono::duration_cast<std::chrono::milliseconds>(t1.time_since_epoch());

--- a/CanInterface/src/CanModuleUtils.cpp
+++ b/CanInterface/src/CanModuleUtils.cpp
@@ -62,12 +62,4 @@ namespace CanModule
 		return std::chrono::system_clock::now();
 	}
 
-#if 0
-	double CanModulesubtractTimeval(const std::chrono::system_clock::time_point &t1, const std::chrono::system_clock::time_point &t2)
-	{
-		std::chrono::duration<double> differ = t2 - t1;
-		return differ.count();
-	}
-
-#endif
 }

--- a/CanInterface/src/CanModuleUtils.cpp
+++ b/CanInterface/src/CanModuleUtils.cpp
@@ -41,16 +41,12 @@ namespace CanModule
 #endif
 	}
 
-	timeval convertTimepointToTimeval(const std::chrono::system_clock::time_point &t1)
-	{
-		timeval dest;
-		auto millisecs = std::chrono::duration_cast<std::chrono::milliseconds>(t1.time_since_epoch());
-		dest.tv_sec = millisecs.count() / 1000;
-		dest.tv_usec = (millisecs.count() % 1000) * 1000;
-		return dest;
-	}
+#ifdef _WIN32
 	// overload for windows implementation errors on chrono
 	timeval convertTimepointToTimeval(const std::chrono::steady_clock::time_point &t1)
+#else
+	timeval convertTimepointToTimeval(const std::chrono::system_clock::time_point &t1)
+#endif
 	{
 		timeval dest;
 		auto millisecs = std::chrono::duration_cast<std::chrono::milliseconds>(t1.time_since_epoch());

--- a/CanInterface/src/CanModuleUtils.cpp
+++ b/CanInterface/src/CanModuleUtils.cpp
@@ -56,7 +56,11 @@ namespace CanModule
 		return dest;
 	}
 
+#ifdef _WIN32
+	std::chrono::steady_clock::time_point convertTimevalToTimepoint(const timeval &t1)
+#else
 	std::chrono::system_clock::time_point convertTimevalToTimepoint(const timeval &t1)
+#endif
 	{
 		auto d = std::chrono::seconds(t1.tv_sec) + std::chrono::nanoseconds(t1.tv_usec);
 		std::chrono::system_clock::time_point tp(std::chrono::duration_cast<std::chrono::system_clock::duration>(d));

--- a/CanInterface/src/CanModuleUtils.cpp
+++ b/CanInterface/src/CanModuleUtils.cpp
@@ -59,18 +59,7 @@ namespace CanModule
 
 	std::chrono::system_clock::time_point currentTimeTimeval()
 	{
-		//	timeval ftTimeStamp;
-
-		auto now = std::chrono::system_clock::now();
-		/*
-		auto nMicrosecs =
-			std::chrono::duration_cast<std::chrono::microseconds>(
-				now.time_since_epoch()
-					);
-			ftTimeStamp.tv_sec = nMicrosecs.count() / 1000000L;
-			ftTimeStamp.tv_usec = (nMicrosecs.count() % 1000000L);
-		 */
-		return now;
+		return std::chrono::system_clock::now();
 	}
 
 	double CanModulesubtractTimeval(const std::chrono::system_clock::time_point &t1, const std::chrono::system_clock::time_point &t2)

--- a/CanInterface/src/CanModuleUtils.cpp
+++ b/CanInterface/src/CanModuleUtils.cpp
@@ -64,7 +64,6 @@ namespace CanModule
 		return tp;
 	}
 #else
-	xx
 	std::chrono::system_clock::time_point convertTimevalToTimepoint(const timeval &t1)
 	{
 		auto d = std::chrono::seconds(t1.tv_sec) + std::chrono::nanoseconds(t1.tv_usec);

--- a/CanInterface/src/CanModuleUtils.cpp
+++ b/CanInterface/src/CanModuleUtils.cpp
@@ -40,7 +40,7 @@ namespace CanModule
 		return std::string(strerror_r(errno, buf, max_len - 1));
 #endif
 	}
-
+#if 0
 	timeval convertTimepointToTimeval(const std::chrono::system_clock::time_point &t1)
 	{
 		timeval dest;
@@ -67,4 +67,6 @@ namespace CanModule
 		std::chrono::duration<double> differ = t2 - t1;
 		return differ.count();
 	}
+
+#endif
 }

--- a/CanInterface/src/CanModuleUtils.cpp
+++ b/CanInterface/src/CanModuleUtils.cpp
@@ -69,7 +69,7 @@ namespace CanModule
 
 	// windows implementation errors on chrono
 #ifdef _WIN32
-	std::chrono::steady_clock::time_point currentTimeTimeval()	{ return std::chrono::ssteady_clock::now();}
+	std::chrono::steady_clock::time_point currentTimeTimeval()	{ return std::chrono::steady_clock::now();}
 #else
 	std::chrono::system_clock::time_point currentTimeTimeval()	{ return std::chrono::system_clock::now();}
 #endif

--- a/CanInterface/src/CanModuleUtils.cpp
+++ b/CanInterface/src/CanModuleUtils.cpp
@@ -49,7 +49,7 @@ namespace CanModule
 		dest.tv_usec = (millisecs.count() % 1000) * 1000;
 		return dest;
 	}
-#if 0
+
 	std::chrono::system_clock::time_point convertTimevalToTimepoint(const timeval &t1)
 	{
 		auto d = std::chrono::seconds(t1.tv_sec) + std::chrono::nanoseconds(t1.tv_usec);
@@ -62,6 +62,7 @@ namespace CanModule
 		return std::chrono::system_clock::now();
 	}
 
+#if 0
 	double CanModulesubtractTimeval(const std::chrono::system_clock::time_point &t1, const std::chrono::system_clock::time_point &t2)
 	{
 		std::chrono::duration<double> differ = t2 - t1;

--- a/CanInterface/src/CanModuleUtils.cpp
+++ b/CanInterface/src/CanModuleUtils.cpp
@@ -41,8 +41,9 @@ namespace CanModule
 #endif
 	}
 
+
+	// windows implementation errors on chrono
 #ifdef _WIN32
-	// overload for windows implementation errors on chrono
 	timeval convertTimepointToTimeval(const std::chrono::steady_clock::time_point &t1)
 #else
 	timeval convertTimepointToTimeval(const std::chrono::system_clock::time_point &t1)
@@ -62,9 +63,11 @@ namespace CanModule
 		return tp;
 	}
 
-	std::chrono::system_clock::time_point currentTimeTimeval()
-	{
-		return std::chrono::system_clock::now();
-	}
+	// windows implementation errors on chrono
+#ifdef _WIN32
+	std::chrono::steady_clock::time_point currentTimeTimeval()	{ return std::chrono::ssteady_clock::now();}
+#else
+	std::chrono::system_clock::time_point currentTimeTimeval()	{ return std::chrono::system_clock::now();}
+#endif
 
 }

--- a/CanInterface/src/CanModuleUtils.cpp
+++ b/CanInterface/src/CanModuleUtils.cpp
@@ -64,6 +64,7 @@ namespace CanModule
 		return tp;
 	}
 #else
+	xx
 	std::chrono::system_clock::time_point convertTimevalToTimepoint(const timeval &t1)
 	{
 		auto d = std::chrono::seconds(t1.tv_sec) + std::chrono::nanoseconds(t1.tv_usec);

--- a/CanInterface/src/CanModuleUtils.cpp
+++ b/CanInterface/src/CanModuleUtils.cpp
@@ -49,6 +49,15 @@ namespace CanModule
 		dest.tv_usec = (millisecs.count() % 1000) * 1000;
 		return dest;
 	}
+	// overload for windows implementation errors on chrono
+	timeval convertTimepointToTimeval(const std::chrono::steady_clock::time_point &t1)
+	{
+		timeval dest;
+		auto millisecs = std::chrono::duration_cast<std::chrono::milliseconds>(t1.time_since_epoch());
+		dest.tv_sec = millisecs.count() / 1000;
+		dest.tv_usec = (millisecs.count() % 1000) * 1000;
+		return dest;
+	}
 
 	std::chrono::system_clock::time_point convertTimevalToTimepoint(const timeval &t1)
 	{

--- a/CanInterface/src/CanModuleUtils.cpp
+++ b/CanInterface/src/CanModuleUtils.cpp
@@ -58,14 +58,19 @@ namespace CanModule
 
 #ifdef _WIN32
 	std::chrono::steady_clock::time_point convertTimevalToTimepoint(const timeval &t1)
+	{
+		auto d = std::chrono::seconds(t1.tv_sec) + std::chrono::nanoseconds(t1.tv_usec);
+		std::chrono::steady_clock::time_point tp(std::chrono::duration_cast<std::chrono::steady_clock::duration>(d));
+		return tp;
+	}
 #else
 	std::chrono::system_clock::time_point convertTimevalToTimepoint(const timeval &t1)
-#endif
 	{
 		auto d = std::chrono::seconds(t1.tv_sec) + std::chrono::nanoseconds(t1.tv_usec);
 		std::chrono::system_clock::time_point tp(std::chrono::duration_cast<std::chrono::system_clock::duration>(d));
 		return tp;
 	}
+#endif
 
 	// windows implementation errors on chrono
 #ifdef _WIN32

--- a/CanInterface/src/CanModuleUtils.cpp
+++ b/CanInterface/src/CanModuleUtils.cpp
@@ -41,12 +41,12 @@ namespace CanModule
 #endif
 	}
 
-#ifdef _WIN32
+//#ifdef _WIN32
 	// overload for windows implementation errors on chrono
-	timeval convertTimepointToTimeval(const std::chrono::steady_clock::time_point &t1)
-#else
+//	timeval convertTimepointToTimeval(const std::chrono::steady_clock::time_point &t1)
+//#else
 	timeval convertTimepointToTimeval(const std::chrono::system_clock::time_point &t1)
-#endif
+//#endif
 	{
 		timeval dest;
 		auto millisecs = std::chrono::duration_cast<std::chrono::milliseconds>(t1.time_since_epoch());

--- a/CanInterface/src/CanStatistics.cpp
+++ b/CanInterface/src/CanStatistics.cpp
@@ -92,9 +92,9 @@ namespace CanModule
 		this->m_receivedOctets = other.m_receivedOctets.load();
 		this->m_internals = other.m_internals;
 
-		this->m_dreceived = other.m_dreceived;
-		this->m_dtransmitted = other.m_dtransmitted;
-		this->m_dopen = other.m_dopen;
-		this->m_dnow = other.m_dnow;
+		this->m_hrreceived = other.m_hrreceived;
+		this->m_hrtransmitted = other.m_hrtransmitted;
+		this->m_hropen = other.m_hropen;
+		this->m_hrnow = other.m_hrnow;
 	}
 }

--- a/CanInterfaceImplementations/sockcan/SockCanScan.cpp
+++ b/CanInterfaceImplementations/sockcan/SockCanScan.cpp
@@ -977,8 +977,6 @@ void CSockCanScan::stopBus ()
 void CSockCanScan::getStatistics( CanStatistics & result )
 {
 	m_statistics.computeDerived (m_CanParameters.m_lBaudRate);
-//	m_statistics.encodeCanModuleStatus();
-
 	result = m_statistics;  // copy whole structure
 	m_statistics.beginNewRun();
 }

--- a/CanInterfaceImplementations/sockcan/SockCanScan.cpp
+++ b/CanInterfaceImplementations/sockcan/SockCanScan.cpp
@@ -926,12 +926,15 @@ void CSockCanScan::clearErrorMessage()
 				<< getBusName()
 				<< " ioctl timestamp from socket failed, setting local time"
 				<< " ioctlReturn = " << ioctlReturn;
-		gettimeofday( &c_time, NULL );
+		xxx gettimeofday( &c_time, NULL );
 	}
 	MLOGSOCK(TRC,this) << "ioctlReturn= " << ioctlReturn;
 	canMessageError(0, errorMessage.c_str(), c_time);
 }
 
+/**
+ * send a timestamped error message
+ */
 void CSockCanScan::sendErrorMessage(const char *mess)
 {
 	timeval c_time;
@@ -941,7 +944,19 @@ void CSockCanScan::sendErrorMessage(const char *mess)
 				<< getBusName()
 				<< " ioctl timestamp from socket failed, setting local time"
 				<< " ioctlReturn = " << ioctlReturn;
-		gettimeofday( &c_time, NULL );
+
+
+		auto now = std::chrono::system_clock::now();
+		c_time = CanModule::CanModuleUtils::convertTimepointToTimeval(&now);
+
+#if 0
+		auto nMicrosecs =
+				duration_cast<std::chrono::microseconds>(
+						now.time_since_epoch()
+				);
+		c_time.tv_sec = nMicrosecs.count() / 1000000L;
+		c_time.tv_usec = (nMicrosecs.count() % 1000000L) ;
+#endif
 	}
 	MLOGSOCK(TRC,this) << "ioctlReturn= " << ioctlReturn;
 	canMessageError(-1,mess,c_time);

--- a/CanInterfaceImplementations/sockcan/SockCanScan.cpp
+++ b/CanInterfaceImplementations/sockcan/SockCanScan.cpp
@@ -926,14 +926,14 @@ void CSockCanScan::clearErrorMessage()
 				<< getBusName()
 				<< " ioctl timestamp from socket failed, setting local time"
 				<< " ioctlReturn = " << ioctlReturn;
-		xxx gettimeofday( &c_time, NULL );
+		c_time = convertTimepointToTimeval( std::chrono::system_clock::now());
 	}
 	MLOGSOCK(TRC,this) << "ioctlReturn= " << ioctlReturn;
 	canMessageError(0, errorMessage.c_str(), c_time);
 }
 
 /**
- * send a timestamped error message
+ * send a timestamped error message, get time from the socket or from chrono
  */
 void CSockCanScan::sendErrorMessage(const char *mess)
 {
@@ -944,19 +944,7 @@ void CSockCanScan::sendErrorMessage(const char *mess)
 				<< getBusName()
 				<< " ioctl timestamp from socket failed, setting local time"
 				<< " ioctlReturn = " << ioctlReturn;
-
-
-		auto now = std::chrono::system_clock::now();
-		c_time = CanModule::CanModuleUtils::convertTimepointToTimeval(&now);
-
-#if 0
-		auto nMicrosecs =
-				duration_cast<std::chrono::microseconds>(
-						now.time_since_epoch()
-				);
-		c_time.tv_sec = nMicrosecs.count() / 1000000L;
-		c_time.tv_usec = (nMicrosecs.count() % 1000000L) ;
-#endif
+		c_time = convertTimepointToTimeval( std::chrono::system_clock::now());
 	}
 	MLOGSOCK(TRC,this) << "ioctlReturn= " << ioctlReturn;
 	canMessageError(-1,mess,c_time);

--- a/CanInterfaceImplementations/sockcan/SockCanScan.cpp
+++ b/CanInterfaceImplementations/sockcan/SockCanScan.cpp
@@ -989,7 +989,8 @@ void CSockCanScan::updateInitialError ()
 	if (m_errorCode == 0) {
 		clearErrorMessage();
 	} else {
-		canMessageError( m_errorCode, "Initial port state: error", convertTimepointToTimeval( std::chrono::system_clock::now()) );
+		timeval now = convertTimepointToTimeval( std::chrono::system_clock::now());
+		canMessageError( m_errorCode, "Initial port state: error", now );
 	}
 }
 

--- a/CanInterfaceImplementations/sockcan/SockCanScan.cpp
+++ b/CanInterfaceImplementations/sockcan/SockCanScan.cpp
@@ -196,8 +196,7 @@ void CSockCanScan::CanScanControlThread()
 			} else {
 				if (status_socketcan == 0) {
 					p_sockCanScan->m_errorCode = 0;
-					timeval t;
-					gettimeofday( &t, 0 );
+					timeval t = convertTimepointToTimeval( std::chrono::system_clock::now());
 					p_sockCanScan->canMessageError( p_sockCanScan->m_errorCode, "CAN port is recovered", t );
 				}
 			}
@@ -214,8 +213,7 @@ void CSockCanScan::CanScanControlThread()
 			// got an error from the socket
 			if (numberOfReadBytes < 0) {
 				MLOGSOCK(ERR,p_sockCanScan) << "read() error: " << CanModuleerrnoToString()<< " tid= " << _tid;;
-				timeval now;
-				gettimeofday( &now, 0 );
+				timeval now = convertTimepointToTimeval( std::chrono::system_clock::now());
 				p_sockCanScan->canMessageError( numberOfReadBytes, ("read() error: "+CanModuleerrnoToString()).c_str(), now );
 				p_sockCanScan->m_errorCode = -1;
 
@@ -292,7 +290,7 @@ void CSockCanScan::CanScanControlThread()
 							<< p_sockCanScan->getBusName()
 							<< " got an error, ioctl timestamp from socket failed as well, setting local time"
 							<< " ioctlReturn1 = " << ioctlReturn1;
-					gettimeofday( &c_time, NULL );
+					c_time = convertTimepointToTimeval( std::chrono::system_clock::now());
 				}
 				MLOGSOCK(ERR, p_sockCanScan) << "SocketCAN ioctl return: [" << ioctlReturn1
 						<< " error frame: [" << description
@@ -334,7 +332,7 @@ void CSockCanScan::CanScanControlThread()
 						<< p_sockCanScan->getBusName()
 						<< " ioctl timestamp from socket failed, setting local time"
 						<< " ioctlReturn2 = " << ioctlReturn2;
-				gettimeofday( &canMessage.c_time, NULL );
+				canMessage.c_time = convertTimepointToTimeval( std::chrono::system_clock::now());
 			}
 
 			MLOGSOCK(TRC, p_sockCanScan) << " SocketCAN ioctl SIOCGSTAMP return: [" << ioctlReturn2 << "]" << " tid= " << _tid;
@@ -993,9 +991,7 @@ void CSockCanScan::updateInitialError ()
 	if (m_errorCode == 0) {
 		clearErrorMessage();
 	} else {
-		timeval now;
-		gettimeofday( &now, 0);
-		canMessageError( m_errorCode, "Initial port state: error", now );
+		canMessageError( m_errorCode, "Initial port state: error", convertTimepointToTimeval( std::chrono::system_clock::now()) );
 	}
 }
 

--- a/CanInterfaceImplementations/sockcan/SockCanScan.h
+++ b/CanInterfaceImplementations/sockcan/SockCanScan.h
@@ -116,13 +116,9 @@ public:
 		m_reconnectAction = action;
 	};
 	virtual void setReconnectReceptionTimeout( unsigned int timeout ){ 	m_timeoutOnReception = timeout;	};
-	virtual void setReconnectFailedSendCount( unsigned int c ){
-		m_maxFailedSendCount = m_failedSendCountdown = c;
-		std::cout << __FILE__ << " " << __LINE__ << " m_triggerCounter= " << m_failedSendCountdown << std::endl;
-	}
+	virtual void setReconnectFailedSendCount( unsigned int c ){	m_maxFailedSendCount = m_failedSendCountdown = c;	}
 	virtual CanModule::ReconnectAutoCondition getReconnectCondition() { return m_reconnectCondition; };
 	virtual CanModule::ReconnectAction getReconnectAction() { return m_reconnectAction; };
-
 	virtual void stopBus ();
 
 private:


### PR DESCRIPTION
- gettimeofday/C++ chrono cleanup to modernize code
- fixing OPCUA-2691: mini release to fix getPortStatus() for "sock", provide a more direct approach
  Now it just goes out directly and does a can_get_state() each time it is invoked, and wraps the result into the unified port as before status.
  port status is NOT part of the statistics any more, suppressed all code related.
  port status is updated each call, not each 10th call or after 10 seconds
  frankly, this makes more sense as well, must have had a bad day when coding the previous implementation ;-)
  not really tested, issue stays open until the OPCUA can open server confirms it. Pretty simple though, should work as-is.
