### PR TITLE
OPCUA-3257 Anagate CANWrite returns 0 even when failing

### DIFF
--- a/python/canmodule/__init__.pyi
+++ b/python/canmodule/__init__.pyi
@@ -53,6 +53,7 @@ class CanDeviceConfiguration:
     bus_name: str | None
     bus_number: int | None
     enable_termination: bool | None
+    high_speed: bool | None
     host: str | None
     sent_acknowledgement: int | None
     timeout: int | None

--- a/src/include/CanDeviceConfiguration.h
+++ b/src/include/CanDeviceConfiguration.h
@@ -56,6 +56,16 @@ struct CanDeviceConfiguration {
   std::optional<bool> enable_termination;
 
   /**
+   * @brief Enable or disable high speed mode on the CAN bus.
+   *
+   * This parameter is used for Anagate devices to enable or disable the high
+   * speed mode on the CAN bus. It is ignored for SocketCAN devices. The high
+   * speed mode supresses the acknowledgment of sent messages, reducing the load
+   * of the Anagate device.
+   */
+  std::optional<bool> high_speed;
+
+  /**
    * @brief The timeout value for CAN operations.
    *
    * This parameter is optional for both Anagate and SocketCAN devices. For

--- a/src/main/CanVendorAnagate.cpp
+++ b/src/main/CanVendorAnagate.cpp
@@ -102,7 +102,11 @@ CanReturnCode CanVendorAnagate::vendor_open() noexcept {
     }
 
     if (args().config.enable_termination.has_value()) {
-      enable_termination = 1;
+      enable_termination = args().config.enable_termination.value() ? 1 : 0;
+    }
+
+    if (args().config.high_speed.has_value()) {
+      args().config.high_speed.value();
     }
 
     // Set the modified configuration

--- a/src/python/CanModule.cpp
+++ b/src/python/CanModule.cpp
@@ -82,6 +82,7 @@ PYBIND11_MODULE(canmodule, m) {
       .def_readwrite("bitrate", &CanDeviceConfiguration::bitrate)
       .def_readwrite("enable_termination",
                      &CanDeviceConfiguration::enable_termination)
+      .def_readwrite("high_speed", &CanDeviceConfiguration::high_speed)
       .def_readwrite("vcan", &CanDeviceConfiguration::vcan)
       .def_readwrite("timeout", &CanDeviceConfiguration::timeout)
       .def_readwrite("sent_acknowledgement",

--- a/test/python/test_anagate.py
+++ b/test/python/test_anagate.py
@@ -209,6 +209,9 @@ def test_anagate_diagnostics():
     )
 
 
+@pytest.mark.skip(
+    reason="Disable this test until Anagate release a new firmware version that reports error on sending 30.01.2025"
+)
 def test_anagate_bus_off_recovery():
     received_frames_dev1 = []
     myDevice1 = CanDevice.create(
@@ -237,4 +240,5 @@ def test_anagate_bus_off_recovery():
         if return_code != CanReturnCode.success:
             send_error_count += 1
     sleep(1)
+
     assert send_error_count > 0

--- a/test/python/test_anagate.py
+++ b/test/python/test_anagate.py
@@ -5,11 +5,17 @@ import platform
 from common import *
 
 DEVICE_ONE = CanDeviceConfiguration()
-DEVICE_ONE.host = "128.141.159.236"
+DEVICE_ONE.host = "ANACANFZ8-010211FC.CERN.CH"
+DEVICE_ONE.bitrate = 125_000
+DEVICE_ONE.enable_termination = True
+DEVICE_ONE.high_speed = False
 DEVICE_ONE.bus_number = 0 if platform.system() == "Linux" else 2
 
 DEVICE_TWO = CanDeviceConfiguration()
-DEVICE_TWO.host = "128.141.159.236"
+DEVICE_TWO.host = DEVICE_ONE.host
+DEVICE_TWO.bitrate = DEVICE_ONE.bitrate
+DEVICE_TWO.enable_termination = False
+DEVICE_TWO.high_speed = DEVICE_ONE.high_speed
 DEVICE_TWO.bus_number = 1 if platform.system() == "Linux" else 3
 
 
@@ -201,3 +207,34 @@ def test_anagate_diagnostics():
     assert stats2.rx_per_second == pytest.approx(
         n_attemps * n_frames / time_elapsed, abs=0.1
     )
+
+
+def test_anagate_bus_off_recovery():
+    received_frames_dev1 = []
+    myDevice1 = CanDevice.create(
+        "anagate", CanDeviceArguments(DEVICE_ONE, received_frames_dev1.append)
+    )
+    myDevice1.open()
+
+    received_frames_dev2 = []
+
+    canDeviceConfig = CanDeviceConfiguration()
+    canDeviceConfig.host = DEVICE_TWO.host
+    canDeviceConfig.bus_number = DEVICE_TWO.bus_number
+    canDeviceConfig.high_speed = DEVICE_ONE.high_speed
+    canDeviceConfig.bitrate = 500_000
+    canDeviceConfig.enable_termination = DEVICE_TWO.enable_termination
+
+    myDevice2 = CanDevice.create(
+        "anagate", CanDeviceArguments(canDeviceConfig, received_frames_dev2.append)
+    )
+    myDevice2.open()
+
+    # Send a few frames to trigger bus off
+    send_error_count = 0
+    for _ in range(100_000):
+        return_code = myDevice2.send(CanFrame(123, ["H", "e", "l", "l", "o"]))
+        if return_code != CanReturnCode.success:
+            send_error_count += 1
+    sleep(1)
+    assert send_error_count > 0


### PR DESCRIPTION
- Test for Anagate CANWrite returns 0 even when failing (waiting for new Anagate firmware to fix that)
- Minor fixes for Anagate during testing