### PR TITLE
OPCUA-3308 Expand support extended ID Python tools

### DIFF
--- a/docs/CANMODULE-UTILS.md
+++ b/docs/CANMODULE-UTILS.md
@@ -34,8 +34,10 @@ Examples of CAN frames are:
 
 ```bash
 001#AA // Message of 1 byte (AA) and standard id 1
-FFFA#BB.BB // Message of 2 bytes (BB BB) and extended if FFFA
+FFFA#BB.BB // Message of 2 bytes (BB BB) and extended id FFFA
 001#R4 // Remote request message with length 4 and standard id 1
+00000123#AA // Message of 1 byte (AA) with small ID sent as extended format
+00000123#R4 // Remote request of length 4 with small ID sent as extended format
 ```
 
 ### gen

--- a/python/canmodule-utils.py
+++ b/python/canmodule-utils.py
@@ -125,18 +125,46 @@ def parse_can_frame(can_frame_str):
           - "len" (int): The number of data bytes for a remote request frame.
           - "data" (list of str): The hexadecimal representation of the CAN data bytes for a data frame.
     """
-    if "R" in can_frame_str:
-        can_id, len_data = can_frame_str.split("#R")
-        frame = {
-            "can_id": can_id,
-            "len": int(len_data),
-        }
+    if "#" not in can_frame_str:
+        raise ValueError("Missing '#' delimiter")
+
+    can_id, payload = can_frame_str.split("#", 1)
+    if not can_id:
+        raise ValueError("Missing CAN ID")
+
+    try:
+        can_id_value = int(can_id, 16)
+    except ValueError as error:
+        raise ValueError(f"Invalid CAN ID '{can_id}'") from error
+
+    if can_id_value > 0x1FFFFFFF:
+        raise ValueError(
+            f"CAN ID 0x{can_id_value:X} is out of range (max 0x1FFFFFFF)"
+        )
+
+    frame = {
+        "can_id": can_id,
+        # cansend-like rule: 8 hex digits force extended format even for small IDs.
+        "id_format_hint": "extended" if len(can_id) == 8 else "auto",
+    }
+
+    if payload.startswith(("R", "r")):
+        len_data = payload[1:]
+        if len_data:
+            try:
+                requested_len = int(len_data)
+            except ValueError as error:
+                raise ValueError(f"Invalid remote request length '{len_data}'") from error
+        else:
+            requested_len = 0
+
+        if requested_len < 0 or requested_len > 8:
+            raise ValueError("Remote request length must be between 0 and 8")
+
+        frame["len"] = requested_len
     else:
-        can_id, data = can_frame_str.split("#")
-        frame = {
-            "can_id": can_id,
-            "data": data.split("."),
-        }
+        frame["data"] = payload.split(".")
+
     return frame
 
 
@@ -222,9 +250,7 @@ def process_frame(frame):
     """
     can_id = int(frame["can_id"], 16)
 
-    extended_id = False
-    if can_id > 0x7FF:  # More than 11 bits long
-        extended_id = True
+    extended_id = frame.get("id_format_hint") == "extended" or can_id > 0x7FF
 
     remote_request = False
     flags = 0

--- a/python/canmodule-utils.py
+++ b/python/canmodule-utils.py
@@ -138,9 +138,7 @@ def parse_can_frame(can_frame_str):
         raise ValueError(f"Invalid CAN ID '{can_id}'") from error
 
     if can_id_value > 0x1FFFFFFF:
-        raise ValueError(
-            f"CAN ID 0x{can_id_value:X} is out of range (max 0x1FFFFFFF)"
-        )
+        raise ValueError(f"CAN ID 0x{can_id_value:X} is out of range (max 0x1FFFFFFF)")
 
     frame = {
         "can_id": can_id,
@@ -154,7 +152,9 @@ def parse_can_frame(can_frame_str):
             try:
                 requested_len = int(len_data)
             except ValueError as error:
-                raise ValueError(f"Invalid remote request length '{len_data}'") from error
+                raise ValueError(
+                    f"Invalid remote request length '{len_data}'"
+                ) from error
         else:
             requested_len = 0
 


### PR DESCRIPTION
Currently, the command-line Python tools in CanModule detect the ID length and automatically choose an extended or standard ID.

It should have an option to send "smalls" IDs using the extended ID format