### PR TITLE
OPCUA-3371 Refactor subscriber method to simplify CAN frame reading logic

### DIFF
--- a/src/main/CanVendorSocketCan.cpp
+++ b/src/main/CanVendorSocketCan.cpp
@@ -388,25 +388,22 @@ int CanVendorSocketCan::subscriber() noexcept {
       }
     }
 
-    for (int i = 0; i < nfds; ++i) {
-      if (events[i].data.fd == m_socket_fd) {
-        struct can_frame canFrame;
-        int nbytes = ::read(m_socket_fd, &canFrame, sizeof(struct can_frame));
-        if (nbytes < 0) {
-          LOG(Log::ERR, CanLogIt::h())
-              << "Unexpected error reading from socket, exiting";
-          return -1;
-        }
+    if (nfds > 0 && events[0].data.fd == m_socket_fd) {
+      struct can_frame canFrame;
+      int nbytes = ::read(m_socket_fd, &canFrame, sizeof(struct can_frame));
+      if (nbytes < 0) {
+        LOG(Log::ERR, CanLogIt::h())
+            << "Unexpected error reading from socket, exiting";
+        return -1;
+      }
 
-        if (nbytes == sizeof(canFrame)) {
-          LOG(Log::DBG, CanLogIt::h()) << "Received CAN frame via SocketCAN";
+      if (nbytes == sizeof(canFrame)) {
+        LOG(Log::DBG, CanLogIt::h()) << "Received CAN frame via SocketCAN";
 
-          CanFrame frame = translate(canFrame);
-          received(
-              frame);  // Call the received method with the translated frame
-        } else {
-          LOG(Log::ERR, CanLogIt::h()) << "Corrupted CanFrame received";
-        }
+        CanFrame frame = translate(canFrame);
+        received(frame);  // Call the received method with the translated frame
+      } else {
+        LOG(Log::ERR, CanLogIt::h()) << "Corrupted CanFrame received";
       }
     }
   }


### PR DESCRIPTION
CLang detected a code-smell:

```
scan-build: Analysis run complete.
scan-build: Analysis results (plist files) deposited in '/builds/quasar-team/CanModule/build-clang/scan-build-reports/2026-06-07-235511-3040-1'
SCAN_PROJECT_COUNT=0
[clang-analysis] Running clang-tidy
Suppressed 1 warnings (1 NOLINT).
1 warning generated.
/builds/quasar-team/CanModule/src/main/CanVendorSocketCan.cpp:392:11: error: Out of bound access to memory after the end of 'events' [clang-analyzer-security.ArrayBound,-warnings-as-errors]
  392 |       if (events[i].data.fd == m_socket_fd) {
      |           ^~~~~~~~~
/builds/quasar-team/CanModule/src/main/CanVendorSocketCan.cpp:377:3: note: Loop condition is true.  Entering loop body
  377 |   while (m_subcriber_run) {
      |   ^
/builds/quasar-team/CanModule/src/main/CanVendorSocketCan.cpp:379:9: note: Assuming 'nfds' is >= 0
  379 |     if (nfds < 0) {
      |         ^~~~~~~~
/builds/quasar-team/CanModule/src/main/CanVendorSocketCan.cpp:379:5: note: Taking false branch
  379 |     if (nfds < 0) {
      |     ^
/builds/quasar-team/CanModule/src/main/CanVendorSocketCan.cpp:391:21: note: Assuming 'i' is < 'nfds'
  391 |     for (int i = 0; i < nfds; ++i) {
      |                     ^~~~~~~~
/builds/quasar-team/CanModule/src/main/CanVendorSocketCan.cpp:391:5: note: Loop condition is true.  Entering loop body
  391 |     for (int i = 0; i < nfds; ++i) {
      |     ^
/builds/quasar-team/CanModule/src/main/CanVendorSocketCan.cpp:392:11: note: Assuming field 'fd' is not equal to field 'm_socket_fd'
  392 |       if (events[i].data.fd == m_socket_fd) {
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/builds/quasar-team/CanModule/src/main/CanVendorSocketCan.cpp:392:7: note: Taking false branch
  392 |       if (events[i].data.fd == m_socket_fd) {
      |       ^
/builds/quasar-team/CanModule/src/main/CanVendorSocketCan.cpp:391:21: note: Assuming 'i' is < 'nfds'
  391 |     for (int i = 0; i < nfds; ++i) {
      |                     ^~~~~~~~
/builds/quasar-team/CanModule/src/main/CanVendorSocketCan.cpp:391:5: note: Loop condition is true.  Entering loop body
  391 |     for (int i = 0; i < nfds; ++i) {
      |     ^
/builds/quasar-team/CanModule/src/main/CanVendorSocketCan.cpp:392:11: note: Access of 'events' at index 1, while it holds only a single 'struct epoll_event' element
  392 |       if (events[i].data.fd == m_socket_fd) {
      |           ^~~~~~~~~
Suppressed 1 warnings (1 NOLINT).
1 warning treated as error
[clang-analysis] clang-tidy findings (project sources only):
/builds/quasar-team/CanModule/src/main/CanVendorSocketCan.cpp:392:11: error: Out of bound access to memory after the end of 'events' [clang-analyzer-security.ArrayBound,-warnings-as-errors]
[clang-analysis] ERROR: analyzer failures detected (scan-invocation-failed=0, scan-build-exit=0, scan-project-findings=0, clang-tidy=1)
```